### PR TITLE
libstagefright: squash exynos4 support

### DIFF
--- a/camera/CameraParameters.cpp
+++ b/camera/CameraParameters.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <camera/CameraParameters.h>
+#include <camera/CameraParametersExtra.h>
 #include <system/graphics.h>
 
 namespace android {
@@ -172,6 +173,10 @@ const char CameraParameters::FOCUS_MODE_CONTINUOUS_PICTURE[] = "continuous-pictu
 // Values for light fx settings
 const char CameraParameters::LIGHTFX_LOWLIGHT[] = "low-light";
 const char CameraParameters::LIGHTFX_HDR[] = "high-dynamic-range";
+
+#ifdef CAMERA_PARAMETERS_EXTRA_C
+CAMERA_PARAMETERS_EXTRA_C
+#endif
 
 CameraParameters::CameraParameters()
                 : mMap()

--- a/camera/CameraParameters.cpp
+++ b/camera/CameraParameters.cpp
@@ -242,6 +242,9 @@ void CameraParameters::unflatten(const String8 &params)
 
 void CameraParameters::set(const char *key, const char *value)
 {
+    if (key == NULL || value == NULL)
+        return;
+
     // XXX i think i can do this with strspn()
     if (strchr(key, '=') || strchr(key, ';')) {
         //XXX ALOGE("Key \"%s\"contains invalid character (= or ;)", key);

--- a/camera/CameraParameters.cpp
+++ b/camera/CameraParameters.cpp
@@ -107,6 +107,7 @@ const char CameraParameters::WHITE_BALANCE_DAYLIGHT[] = "daylight";
 const char CameraParameters::WHITE_BALANCE_CLOUDY_DAYLIGHT[] = "cloudy-daylight";
 const char CameraParameters::WHITE_BALANCE_TWILIGHT[] = "twilight";
 const char CameraParameters::WHITE_BALANCE_SHADE[] = "shade";
+const char CameraParameters::WHITE_BALANCE_MANUAL_CCT[] = "manual-cct";
 
 // Values for effect settings.
 const char CameraParameters::EFFECT_NONE[] = "none";
@@ -169,6 +170,7 @@ const char CameraParameters::FOCUS_MODE_FIXED[] = "fixed";
 const char CameraParameters::FOCUS_MODE_EDOF[] = "edof";
 const char CameraParameters::FOCUS_MODE_CONTINUOUS_VIDEO[] = "continuous-video";
 const char CameraParameters::FOCUS_MODE_CONTINUOUS_PICTURE[] = "continuous-picture";
+const char CameraParameters::FOCUS_MODE_MANUAL_POSITION[] = "manual";
 
 // Values for light fx settings
 const char CameraParameters::LIGHTFX_LOWLIGHT[] = "low-light";

--- a/include/camera/CameraParameters.h
+++ b/include/camera/CameraParameters.h
@@ -19,6 +19,7 @@
 
 #include <utils/KeyedVector.h>
 #include <utils/String8.h>
+#include <camera/CameraParametersExtra.h>
 
 namespace android {
 
@@ -682,6 +683,10 @@ public:
     static const char LIGHTFX_LOWLIGHT[];
     // High-dynamic range mode
     static const char LIGHTFX_HDR[];
+
+#ifdef CAMERA_PARAMETERS_EXTRA_H
+CAMERA_PARAMETERS_EXTRA_H
+#endif
 
     /**
      * Returns the the supported preview formats as an enum given in graphics.h

--- a/include/camera/CameraParameters.h
+++ b/include/camera/CameraParameters.h
@@ -555,6 +555,7 @@ public:
     static const char WHITE_BALANCE_CLOUDY_DAYLIGHT[];
     static const char WHITE_BALANCE_TWILIGHT[];
     static const char WHITE_BALANCE_SHADE[];
+    static const char WHITE_BALANCE_MANUAL_CCT[];
 
     // Values for effect settings.
     static const char EFFECT_NONE[];
@@ -677,6 +678,8 @@ public:
     // To stop continuous focus, applications should change the focus mode to
     // other modes.
     static const char FOCUS_MODE_CONTINUOUS_PICTURE[];
+
+    static const char FOCUS_MODE_MANUAL_POSITION[];
 
     // Values for light special effects
     // Low-light enhancement mode

--- a/include/camera/CameraParametersExtra.h
+++ b/include/camera/CameraParametersExtra.h
@@ -1,0 +1,35 @@
+// Overload this file in your device specific config if you need
+// to add extra camera parameters.
+// A typical file would look like this:
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+#define CAMERA_PARAMETERS_EXTRA_C \
+const char CameraParameters::KEY_SUPPORTED_BURST_NUM[] = "supported-burst-num"; \
+const char CameraParameters::KEY_BURST_NUM[] = "burst-num"; \
+const char CameraParameters::KEY_SUPPORTED_HDR_MODES[] = "supported-hdr-modes"; \
+const char CameraParameters::KEY_HDR_MODE[] = "hdr-mode"; \
+const char CameraParameters::HDR_MODE_OFF[] = "hdr-mode-off"; \
+const char CameraParameters::HDR_MODE_HDR[] = "hdr-mode-hdr";
+
+#define CAMERA_PARAMETERS_EXTRA_H \
+    static const char KEY_SUPPORTED_BURST_NUM[]; \
+    static const char KEY_BURST_NUM[]; \
+    static const char KEY_SUPPORTED_HDR_MODES[]; \
+    static const char KEY_HDR_MODE[]; \
+    static const char HDR_MODE_OFF[]; \
+    static const char HDR_MODE_HDR[];
+*/

--- a/include/media/stagefright/ACodec.h
+++ b/include/media/stagefright/ACodec.h
@@ -310,6 +310,9 @@ protected:
     status_t submitOutputMetadataBuffer();
     void signalSubmitOutputMetadataBufferIfEOS_workaround();
     status_t allocateOutputBuffersFromNativeWindow();
+#ifdef USE_SAMSUNG_COLORFORMAT
+    void setNativeWindowColorFormat(OMX_COLOR_FORMATTYPE &eNativeColorFormat);
+#endif
     status_t cancelBufferToNativeWindow(BufferInfo *info);
     status_t freeOutputBuffersNotOwnedByComponent();
     BufferInfo *dequeueBufferFromNativeWindow();

--- a/include/media/stagefright/ACodec.h
+++ b/include/media/stagefright/ACodec.h
@@ -47,6 +47,8 @@
 #include <media/stagefright/SkipCutBuffer.h>
 #include <OMX_Audio.h>
 
+#include <system/audio.h>
+
 #define TRACK_BUFFER_TIMING     0
 
 namespace android {
@@ -364,9 +366,11 @@ protected:
             int32_t maxOutputChannelCount, const drcParams_t& drc,
             int32_t pcmLimiterEnable);
 
-    status_t setupAC3Codec(bool encoder, int32_t numChannels, int32_t sampleRate);
+    status_t setupAC3Codec(bool encoder, int32_t numChannels, int32_t sampleRate,
+            int32_t bitsPerSample = 16);
 
-    status_t setupEAC3Codec(bool encoder, int32_t numChannels, int32_t sampleRate);
+    status_t setupEAC3Codec(bool encoder, int32_t numChannels, int32_t sampleRate,
+            int32_t bitsPerSample = 16);
 
     status_t selectAudioPortFormat(
             OMX_U32 portIndex, OMX_AUDIO_CODINGTYPE desiredFormat);
@@ -378,7 +382,8 @@ protected:
             bool encoder, int32_t numChannels, int32_t sampleRate, int32_t compressionLevel);
 
     status_t setupRawAudioFormat(
-            OMX_U32 portIndex, int32_t sampleRate, int32_t numChannels);
+            OMX_U32 portIndex, int32_t sampleRate, int32_t numChannels,
+            int32_t bitsPerSample = 16);
 
     status_t setPriority(int32_t priority);
     status_t setOperatingRate(float rateFloat, bool isVideo);

--- a/include/media/stagefright/DataSource.h
+++ b/include/media/stagefright/DataSource.h
@@ -62,7 +62,10 @@ public:
 private:
     Mutex mSnifferMutex;
     List<SnifferFunc> mSniffers;
+    List<SnifferFunc> mExtraSniffers;
     List<SnifferFunc>::iterator extendedSnifferPosition;
+
+    void registerSnifferPlugin();
 
     Sniffer(const Sniffer &);
     Sniffer &operator=(const Sniffer &);
@@ -145,6 +148,7 @@ protected:
     sp<Sniffer> mSniffer;
 
     static void RegisterSniffer_l(SnifferFunc func);
+    static void RegisterSnifferPlugin();
 
     DataSource(const DataSource &);
     DataSource &operator=(const DataSource &);

--- a/include/media/stagefright/DataSource.h
+++ b/include/media/stagefright/DataSource.h
@@ -36,6 +36,37 @@ class  IDataSource;
 struct IMediaHTTPService;
 class String8;
 struct HTTPBase;
+class DataSource;
+
+class Sniffer : public RefBase {
+public:
+    Sniffer();
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    bool sniff(DataSource *source, String8 *mimeType, float *confidence, sp<AMessage> *meta);
+
+    // The sniffer can optionally fill in "meta" with an AMessage containing
+    // a dictionary of values that helps the corresponding extractor initialize
+    // its state without duplicating effort already exerted by the sniffer.
+    typedef bool (*SnifferFunc)(
+            const sp<DataSource> &source, String8 *mimeType,
+            float *confidence, sp<AMessage> *meta);
+
+    //if isExtendedExtractor = true, store the location of the sniffer to register
+    void registerSniffer_l(SnifferFunc func);
+    void registerDefaultSniffers();
+
+    virtual ~Sniffer() {}
+
+private:
+    Mutex mSnifferMutex;
+    List<SnifferFunc> mSniffers;
+    List<SnifferFunc>::iterator extendedSnifferPosition;
+
+    Sniffer(const Sniffer &);
+    Sniffer &operator=(const Sniffer &);
+};
 
 class DataSource : public RefBase {
 public:
@@ -57,7 +88,7 @@ public:
     static sp<DataSource> CreateMediaHTTP(const sp<IMediaHTTPService> &httpService);
     static sp<DataSource> CreateFromIDataSource(const sp<IDataSource> &source);
 
-    DataSource() {}
+    DataSource() : mSniffer(new Sniffer()) {}
 
     virtual status_t initCheck() const = 0;
 
@@ -111,10 +142,7 @@ public:
 protected:
     virtual ~DataSource() {}
 
-private:
-    static Mutex gSnifferMutex;
-    static List<SnifferFunc> gSniffers;
-    static bool gSniffersRegistered;
+    sp<Sniffer> mSniffer;
 
     static void RegisterSniffer_l(SnifferFunc func);
 

--- a/include/media/stagefright/FFMPEGSoftCodec.h
+++ b/include/media/stagefright/FFMPEGSoftCodec.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FFMPEG_SOFT_CODEC_H_
+#define FFMPEG_SOFT_CODEC_H_
+
+#include <media/IOMX.h>
+#include <media/MediaCodecInfo.h>
+
+#include <media/stagefright/foundation/AMessage.h>
+#include <media/stagefright/foundation/AString.h>
+
+#include <media/stagefright/MetaData.h>
+
+#include <OMX_Audio.h>
+#include <OMX_Video.h>
+
+namespace android {
+
+struct FFMPEGSoftCodec {
+
+    enum {
+        kPortIndexInput  = 0,
+        kPortIndexOutput = 1
+    };
+
+    static void convertMessageToMetaDataFF(
+            const sp<AMessage> &msg, sp<MetaData> &meta);
+
+    static void convertMetaDataToMessageFF(
+        const sp<MetaData> &meta, sp<AMessage> *format);
+
+    static const char* overrideComponentName(
+            uint32_t quirks, const sp<MetaData> &meta,
+            const char *mime, bool isEncoder);
+
+    static void overrideComponentName(
+            uint32_t quirks, const sp<AMessage> &msg,
+            AString* componentName, AString* mime,
+            int32_t isEncoder);
+
+    static status_t setSupportedRole(
+            const sp<IOMX> &omx, IOMX::node_id node,
+            bool isEncoder, const char *mime);
+
+    static status_t setAudioFormat(
+            const sp<AMessage> &msg, const char* mime,
+            sp<IOMX> OMXhandle, IOMX::node_id nodeID);
+
+    static status_t setVideoFormat(
+            const sp<AMessage> &msg, const char* mime,
+            sp<IOMX> OMXhandle,IOMX::node_id nodeID,
+            bool isEncoder, OMX_VIDEO_CODINGTYPE *compressionFormat);
+
+    static status_t getAudioPortFormat(
+            OMX_U32 portIndex, int coding,
+            sp<AMessage> &notify, sp<IOMX> OMXhandle, IOMX::node_id nodeID);
+
+    static status_t getVideoPortFormat(
+            OMX_U32 portIndex, int coding,
+            sp<AMessage> &notify, sp<IOMX> OMXhandle, IOMX::node_id nodeID);
+
+private:
+    static const char* getMsgKey(int key);
+
+    static status_t setWMVFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setRVFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setFFmpegVideoFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setRawAudioFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setWMAFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setVORBISFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setRAFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setFLACFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setMP2Format(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setAC3Format(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setAPEFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setDTSFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+    static status_t setFFmpegAudioFormat(
+            const sp<AMessage> &msg, sp<IOMX> OMXhandle,
+            IOMX::node_id nodeID);
+
+};
+
+}
+#endif

--- a/include/media/stagefright/FileSource.h
+++ b/include/media/stagefright/FileSource.h
@@ -39,6 +39,10 @@ public:
 
     virtual status_t getSize(off64_t *size);
 
+    virtual String8 getUri() {
+        return mUri;
+    }
+
     virtual sp<DecryptHandle> DrmInitialization(const char *mime);
 
     virtual void getDrmInfo(sp<DecryptHandle> &handle, DrmManagerClient **client);
@@ -48,6 +52,7 @@ protected:
 
 private:
     int mFd;
+    String8 mUri;
     int64_t mOffset;
     int64_t mLength;
     Mutex mLock;
@@ -60,6 +65,7 @@ private:
     unsigned char *mDrmBuf;
 
     ssize_t readAtDRM(off64_t offset, void *data, size_t size);
+    void fetchUriFromFd(int fd);
 
     FileSource(const FileSource &);
     FileSource &operator=(const FileSource &);

--- a/include/media/stagefright/MediaDefs.h
+++ b/include/media/stagefright/MediaDefs.h
@@ -88,6 +88,41 @@ extern const char *MEDIA_MIMETYPE_TEXT_VTT;
 extern const char *MEDIA_MIMETYPE_TEXT_CEA_608;
 extern const char *MEDIA_MIMETYPE_DATA_TIMED_ID3;
 
+extern const char *MEDIA_MIMETYPE_AUDIO_EAC3_JOC;
+extern const char *MEDIA_MIMETYPE_AUDIO_EAC3;
+
+extern const char *MEDIA_MIMETYPE_VIDEO_FLV1;
+extern const char *MEDIA_MIMETYPE_VIDEO_MJPEG;
+extern const char *MEDIA_MIMETYPE_VIDEO_RV;
+extern const char *MEDIA_MIMETYPE_VIDEO_VC1;
+extern const char *MEDIA_MIMETYPE_VIDEO_WMV;
+extern const char *MEDIA_MIMETYPE_VIDEO_HEVC;
+extern const char *MEDIA_MIMETYPE_VIDEO_FFMPEG;
+
+extern const char *MEDIA_MIMETYPE_AUDIO_AC3;
+extern const char *MEDIA_MIMETYPE_AUDIO_PCM;
+extern const char *MEDIA_MIMETYPE_AUDIO_RA;
+extern const char *MEDIA_MIMETYPE_AUDIO_WMA;
+extern const char *MEDIA_MIMETYPE_AUDIO_FFMPEG;
+
+extern const char *MEDIA_MIMETYPE_CONTAINER_APE;
+extern const char *MEDIA_MIMETYPE_CONTAINER_DIVX;
+extern const char *MEDIA_MIMETYPE_CONTAINER_DTS;
+extern const char *MEDIA_MIMETYPE_CONTAINER_FLAC;
+extern const char *MEDIA_MIMETYPE_CONTAINER_FLV;
+extern const char *MEDIA_MIMETYPE_CONTAINER_MOV;
+extern const char *MEDIA_MIMETYPE_CONTAINER_MP2;
+extern const char *MEDIA_MIMETYPE_CONTAINER_MPG;
+extern const char *MEDIA_MIMETYPE_CONTAINER_RA;
+extern const char *MEDIA_MIMETYPE_CONTAINER_RM;
+extern const char *MEDIA_MIMETYPE_CONTAINER_TS;
+extern const char *MEDIA_MIMETYPE_CONTAINER_WEBM;
+extern const char *MEDIA_MIMETYPE_CONTAINER_VC1;
+extern const char *MEDIA_MIMETYPE_CONTAINER_HEVC;
+extern const char *MEDIA_MIMETYPE_CONTAINER_WMA;
+extern const char *MEDIA_MIMETYPE_CONTAINER_WMV;
+extern const char *MEDIA_MIMETYPE_CONTAINER_FFMPEG;
+
 }  // namespace android
 
 #include <media/stagefright/ExtendedMediaDefs.h>

--- a/include/media/stagefright/MediaExtractor.h
+++ b/include/media/stagefright/MediaExtractor.h
@@ -19,15 +19,27 @@
 #define MEDIA_EXTRACTOR_H_
 
 #include <utils/RefBase.h>
+#include <media/stagefright/DataSource.h>
 
 namespace android {
 
-class DataSource;
 class MediaSource;
 class MetaData;
 
 class MediaExtractor : public RefBase {
 public:
+    typedef MediaExtractor *(*CreateFunc)(const sp<DataSource> &source,
+            const char *mime, const sp<AMessage> &meta);
+
+    struct Plugin {
+        DataSource::SnifferFunc sniff;
+        CreateFunc create;
+    };
+
+    static Plugin *getPlugin() {
+        return &sPlugin;
+    }
+
     static sp<MediaExtractor> Create(
             const sp<DataSource> &source, const char *mime = NULL,
             const uint32_t flags = 0);
@@ -76,6 +88,7 @@ protected:
 
 private:
     bool mIsDrm;
+    static Plugin sPlugin;
 
     MediaExtractor(const MediaExtractor &);
     MediaExtractor &operator=(const MediaExtractor &);

--- a/include/media/stagefright/MetaData.h
+++ b/include/media/stagefright/MetaData.h
@@ -50,6 +50,10 @@ enum {
     kKeySampleRate        = 'srte',  // int32_t (audio sampling rate Hz)
     kKeyFrameRate         = 'frmR',  // int32_t (video frame rate fps)
     kKeyBitRate           = 'brte',  // int32_t (bps)
+    kKeyCodecId           = 'cdid',  // int32_t
+    kKeyBitsPerSample     = 'sbit',  // int32_t (DUPE of kKeySampleBits)
+    kKeyCodedSampleBits   = 'cosb',  // int32_t
+    kKeySampleFormat      = 'sfmt',  // int32_t
     kKeyESDS              = 'esds',  // raw data
     kKeyAACProfile        = 'aacp',  // int32_t
     kKeyAVCC              = 'avcc',  // raw data
@@ -131,6 +135,23 @@ enum {
 
     kKeyIsUnreadable      = 'unre',  // bool (int32_t)
 
+    kKeyRawCodecSpecificData = 'rcsd',  // raw data - added to support mmParser
+    kKeyDivXVersion       = 'DivX',  // int32_t
+    kKeyDivXDrm           = 'QDrm',  // void *
+    kKeyWMAEncodeOpt      = 'eopt',  // int32_t
+    kKeyWMABlockAlign     = 'blka',  // int32_t
+    kKeyWMAVersion        = 'wmav',  // int32_t
+    kKeyWMAAdvEncOpt1     = 'ade1',  // int16_t
+    kKeyWMAAdvEncOpt2     = 'ade2',  // int32_t
+    kKeyWMAFormatTag      = 'fmtt',  // int64_t
+    kKeyWMABitspersample  = 'bsps',  // int64_t
+    kKeyWMAVirPktSize     = 'vpks',  // int64_t
+    kKeyWMVProfile        = 'wmvp',  // int32_t
+
+    kKeyWMVVersion        = 'wmvv',  // int32_t
+    kKeyRVVersion         = '#rvv',  // int32_t
+    kKeyBlockAlign        = 'blk',   // int32_t , should be different from kKeyWMABlockAlign
+
     // An indication that a video buffer has been rendered.
     kKeyRendered          = 'rend',  // bool (int32_t)
 
@@ -181,6 +202,9 @@ enum {
 
     // H264 supplemental enhancement information offsets/sizes
     kKeySEI               = 'sei ', // raw data
+
+    kKeyPCMFormat         = 'pfmt',
+    kKeyArbitraryMode     = 'ArbM',
 };
 
 enum {
@@ -188,6 +212,32 @@ enum {
     kTypeAVCC        = 'avcc',
     kTypeHVCC        = 'hvcc',
     kTypeD263        = 'd263',
+};
+
+enum {
+    kTypeDivXVer_3_11,
+    kTypeDivXVer_4,
+    kTypeDivXVer_5,
+    kTypeDivXVer_6,
+};
+
+enum {
+    kTypeWMA,
+    kTypeWMAPro,
+    kTypeWMALossLess,
+};
+
+enum {
+    kTypeWMVVer_7, // WMV1
+    kTypeWMVVer_8, // WMV2
+    kTypeWMVVer_9, // WMV3
+};
+
+// http://en.wikipedia.org/wiki/RealVideo
+enum {
+    kTypeRVVer_G2, // rv20: RealVideo G2
+    kTypeRVVer_8,  // rv30: RealVideo 8
+    kTypeRVVer_9,  // rv40: RealVideo 9
 };
 
 class MetaData : public RefBase {

--- a/include/media/stagefright/MetaData.h
+++ b/include/media/stagefright/MetaData.h
@@ -150,7 +150,7 @@ enum {
 
     kKeyWMVVersion        = 'wmvv',  // int32_t
     kKeyRVVersion         = '#rvv',  // int32_t
-    kKeyBlockAlign        = 'blk',   // int32_t , should be different from kKeyWMABlockAlign
+    kKeyBlockAlign        = 'ablk',   // int32_t , should be different from kKeyWMABlockAlign
 
     // An indication that a video buffer has been rendered.
     kKeyRendered          = 'rend',  // bool (int32_t)

--- a/media/libavextensions/Android.mk
+++ b/media/libavextensions/Android.mk
@@ -12,7 +12,7 @@ LOCAL_C_INCLUDES:= \
         $(TOP)/frameworks/native/include/media/hardware \
         $(TOP)/frameworks/native/include/media/openmax \
         $(TOP)/external/flac/include \
-        $(TOP)/hardware/qcom/media/mm-core/inc \
+        $(TOP)/$(call project-path-for,qcom-media)/mm-core/inc \
         $(TOP)/frameworks/av/media/libstagefright \
         $(TOP)/frameworks/av/media/libstagefright/mpeg2ts \
 
@@ -42,7 +42,7 @@ LOCAL_C_INCLUDES:= \
         $(TOP)/frameworks/native/include/media/hardware \
         $(TOP)/frameworks/native/include/media/openmax \
         $(TOP)/external/flac/include \
-        $(TOP)/hardware/qcom/media/mm-core/inc
+        $(TOP)/$(call project-path-for,qcom-media)/mm-core/inc
 
 LOCAL_CFLAGS += -Wno-multichar -Werror
 
@@ -76,7 +76,7 @@ LOCAL_C_INCLUDES:= \
         $(TOP)/frameworks/native/include/media/hardware \
         $(TOP)/frameworks/native/include/media/openmax \
         $(TOP)/external/flac/include \
-        $(TOP)/hardware/qcom/media/mm-core/inc
+        $(TOP)/$(call project-path-for,qcom-media)/mm-core/inc
 
 LOCAL_CFLAGS += -Wno-multichar -Werror
 

--- a/media/libavextensions/Android.mk
+++ b/media/libavextensions/Android.mk
@@ -14,6 +14,7 @@ LOCAL_C_INCLUDES:= \
         $(TOP)/external/flac/include \
         $(TOP)/hardware/qcom/media/mm-core/inc \
         $(TOP)/frameworks/av/media/libstagefright \
+        $(TOP)/frameworks/av/media/libstagefright/mpeg2ts \
 
 LOCAL_CFLAGS += -Wno-multichar -Werror
 

--- a/media/libavextensions/mediaplayerservice/AVNuUtils.cpp
+++ b/media/libavextensions/mediaplayerservice/AVNuUtils.cpp
@@ -33,6 +33,8 @@
 #include <media/stagefright/foundation/ADebug.h>
 #include <media/stagefright/foundation/AMessage.h>
 
+#include <media/stagefright/MediaDefs.h>
+
 #include <nuplayer/NuPlayer.h>
 #include <nuplayer/NuPlayerDecoderBase.h>
 #include <nuplayer/NuPlayerDecoderPassThrough.h>
@@ -52,12 +54,29 @@ bool AVNuUtils::pcmOffloadException(const sp<MetaData> &) {
     return true;
 }
 
-bool AVNuUtils::isRAWFormat(const sp<MetaData> &) {
-    return false;
+bool AVNuUtils::isRAWFormat(const sp<MetaData> &meta) {
+    const char *mime = {0};
+    if (meta == NULL) {
+        return false;
+    }
+    CHECK(meta->findCString(kKeyMIMEType, &mime));
+    if (!strncasecmp(mime, MEDIA_MIMETYPE_AUDIO_RAW, 9))
+        return true;
+    else
+        return false;
 }
 
-bool AVNuUtils::isRAWFormat(const sp<AMessage> &) {
-    return false;
+bool AVNuUtils::isRAWFormat(const sp<AMessage> &format) {
+    AString mime;
+    if (format == NULL) {
+        return false;
+    }
+    CHECK(format->findString("mime", &mime));
+    if (!strncasecmp(mime.c_str(), MEDIA_MIMETYPE_AUDIO_RAW, 9))
+        return true;
+    else
+        return false;
+
 }
 
 bool AVNuUtils::isVorbisFormat(const sp<MetaData> &) {
@@ -69,20 +88,39 @@ int AVNuUtils::updateAudioBitWidth(audio_format_t /*audioFormat*/,
     return 16;
 }
 
-audio_format_t AVNuUtils::getKeyPCMFormat(const sp<MetaData> &) {
-    return AUDIO_FORMAT_INVALID;
-}
+audio_format_t AVNuUtils::getKeyPCMFormat(const sp<MetaData> &meta) {
+    int32_t pcmFormat = 0;
+    if (meta->findInt32('pfmt', &pcmFormat))
+        return (audio_format_t)pcmFormat;
 
-void AVNuUtils::setKeyPCMFormat(const sp<MetaData> &, audio_format_t /*audioFormat*/) {
-
-}
-
-audio_format_t AVNuUtils::getPCMFormat(const sp<AMessage> &) {
     return AUDIO_FORMAT_PCM_16_BIT;
 }
 
-void AVNuUtils::setPCMFormat(const sp<AMessage> &, audio_format_t /*audioFormat*/) {
+void AVNuUtils::setKeyPCMFormat(const sp<MetaData> &meta, audio_format_t audioFormat) {
+    if (audio_is_linear_pcm(audioFormat))
+        meta->setInt32('pfmt', audioFormat);
+}
 
+audio_format_t AVNuUtils::getPCMFormat(const sp<AMessage> &format) {
+    int32_t pcmFormat = 0;
+    if (format->findInt32("pcm-format", &pcmFormat))
+        return (audio_format_t)pcmFormat;
+
+    int32_t bits = 16;
+    if (format->findInt32("bit-width", &bits)) {
+        if (bits == 8)
+            return AUDIO_FORMAT_PCM_8_BIT;
+        if (bits == 24)
+            return AUDIO_FORMAT_PCM_32_BIT;
+        if (bits == 32)
+            return AUDIO_FORMAT_PCM_FLOAT;
+    }
+    return AUDIO_FORMAT_PCM_16_BIT;
+}
+
+void AVNuUtils::setPCMFormat(const sp<AMessage> &format, audio_format_t audioFormat) {
+    if (audio_is_linear_pcm(audioFormat))
+        format->setInt32("pcm-format", audioFormat);
 }
 
 void AVNuUtils::setSourcePCMFormat(const sp<MetaData> &) {

--- a/media/libavextensions/stagefright/AVExtensions.h
+++ b/media/libavextensions/stagefright/AVExtensions.h
@@ -35,6 +35,7 @@
 #include <camera/ICamera.h>
 #include <media/mediarecorder.h>
 #include <media/IOMX.h>
+#include "ESQueue.h"
 
 namespace android {
 
@@ -78,6 +79,8 @@ struct AVFactory {
             bool disconnectAtHighwatermark = false);
     virtual MediaHTTP* createMediaHTTP(
             const sp<IMediaHTTPConnection> &conn);
+    virtual ElementaryStreamQueue* createESQueue(
+            ElementaryStreamQueue::Mode mode, uint32_t flags = 0);
 
     virtual AudioSource* createAudioSource(
             audio_source_t inputSource,
@@ -206,6 +209,9 @@ struct AVUtils {
     virtual void setIntraPeriod(
                 int nPFrames, int nBFrames, const sp<IOMX> OMXhandle,
                 IOMX::node_id nodeID);
+
+    // Used by ATSParser
+    virtual bool IsHevcIDR(const sp<ABuffer> &accessUnit);
 
 private:
     HEVCMuxer mHEVCMuxer;

--- a/media/libavextensions/stagefright/AVFactory.cpp
+++ b/media/libavextensions/stagefright/AVFactory.cpp
@@ -126,6 +126,11 @@ MPEG4Writer* AVFactory::CreateMPEG4Writer(int fd) {
     return new MPEG4Writer(fd);
 }
 
+ElementaryStreamQueue* AVFactory::createESQueue(
+         ElementaryStreamQueue::Mode , uint32_t ) {
+    return NULL;
+}
+
 // ----- NO TRESSPASSING BEYOND THIS LINE ------
 AVFactory::AVFactory() {
 }

--- a/media/libavextensions/stagefright/AVUtils.cpp
+++ b/media/libavextensions/stagefright/AVUtils.cpp
@@ -66,8 +66,10 @@ int AVUtils::getAudioSampleBits(const sp<MetaData> &) {
     return 16;
 }
 
-int AVUtils::getAudioSampleBits(const sp<AMessage> &) {
-    return 16;
+int AVUtils::getAudioSampleBits(const sp<AMessage> &format) {
+    int32_t bits = 16;
+    format->findInt32("bit-width", &bits);
+    return bits;
 }
 
 void AVUtils::setPcmSampleBits(const sp<AMessage> &, int32_t /*bitWidth*/) {

--- a/media/libavextensions/stagefright/AVUtils.cpp
+++ b/media/libavextensions/stagefright/AVUtils.cpp
@@ -179,6 +179,10 @@ const char *AVUtils::getCustomCodecsPerformanceLocation() {
     return "/etc/media_codecs_performance.xml";
 }
 
+bool AVUtils::IsHevcIDR(const sp<ABuffer> &) {
+   return false;
+}
+
 // ----- NO TRESSPASSING BEYOND THIS LINE ------
 AVUtils::AVUtils() {}
 

--- a/media/libmedia/AudioRecord.cpp
+++ b/media/libmedia/AudioRecord.cpp
@@ -276,7 +276,11 @@ status_t AudioRecord::set(
     mActive = false;
     mUserData = user;
     // TODO: add audio hardware input latency here
-    mLatency = (1000*mFrameCount) / sampleRate;
+    if (mTransfer == TRANSFER_CALLBACK) {
+        mLatency = (1000*mNotificationFramesAct) / sampleRate;
+    } else {
+        mLatency = (1000*mFrameCount) / sampleRate;
+    }
     mMarkerPosition = 0;
     mMarkerReached = false;
     mNewPosition = 0;

--- a/media/libmedia/AudioTrack.cpp
+++ b/media/libmedia/AudioTrack.cpp
@@ -1297,7 +1297,7 @@ status_t AudioTrack::createTrack_l()
         trackFlags |= IAudioFlinger::TRACK_OFFLOAD;
     }
 
-    if (mFlags & AUDIO_OUTPUT_FLAG_DIRECT) {
+    if ((mFlags & AUDIO_OUTPUT_FLAG_DIRECT) || mTrackOffloaded) {
         trackFlags |= IAudioFlinger::TRACK_DIRECT;
     }
 

--- a/media/libmedia/ICrypto.cpp
+++ b/media/libmedia/ICrypto.cpp
@@ -326,7 +326,9 @@ status_t BnCrypto::onTransact(
 
             if (overflow || sumSubsampleSizes != totalSize) {
                 result = -EINVAL;
-            } else if (offset + totalSize > sharedBuffer->size()) {
+            } else if (totalSize > sharedBuffer->size()) {
+                result = -EINVAL;
+            } else if ((size_t)offset > sharedBuffer->size() - totalSize) {
                 result = -EINVAL;
             } else {
                 result = decrypt(

--- a/media/libmediaplayerservice/Android.mk
+++ b/media/libmediaplayerservice/Android.mk
@@ -56,6 +56,7 @@ LOCAL_C_INCLUDES :=                                                 \
     $(TOP)/frameworks/native/include/media/openmax                  \
     $(TOP)/external/tremolo/Tremolo                                 \
     $(TOP)/frameworks/av/media/libavextensions                      \
+    $(TOP)/frameworks/av/media/libstagefright/mpeg2ts               \
 
 LOCAL_CFLAGS += -Werror -Wno-error=deprecated-declarations -Wall
 LOCAL_CLANG := true

--- a/media/libmediaplayerservice/nuplayer/Android.mk
+++ b/media/libmediaplayerservice/nuplayer/Android.mk
@@ -24,7 +24,8 @@ LOCAL_C_INCLUDES := \
 	$(TOP)/frameworks/av/media/libstagefright/timedtext           \
 	$(TOP)/frameworks/av/media/libmediaplayerservice              \
 	$(TOP)/frameworks/native/include/media/openmax                \
-        $(TOP)/frameworks/av/media/libavextensions                    \
+	$(TOP)/frameworks/av/media/libavextensions                    \
+	$(TOP)/frameworks/av/include/media                            \
 
 LOCAL_CFLAGS += -Werror -Wall
 

--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
@@ -1143,6 +1143,7 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
                 int32_t reason;
                 CHECK(msg->findInt32("reason", &reason));
                 ALOGV("Tear down audio with reason %d.", reason);
+                mAudioDecoder->pause();
                 mAudioDecoder.clear();
                 ++mAudioDecoderGeneration;
                 bool needsToCreateAudioDecoder = true;

--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
@@ -1143,7 +1143,46 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
                 int32_t reason;
                 CHECK(msg->findInt32("reason", &reason));
                 ALOGV("Tear down audio with reason %d.", reason);
-                performTearDown(msg);
+
+                if (ifDecodedPCMOffload()) {
+                    tearDownPCMOffload(msg);
+                    break;
+                }
+
+                mAudioDecoder.clear();
+                ++mAudioDecoderGeneration;
+                bool needsToCreateAudioDecoder = true;
+                if (mFlushingAudio == FLUSHING_DECODER) {
+                    mFlushComplete[1 /* audio */][1 /* isDecoder */] = true;
+                    mFlushingAudio = FLUSHED;
+                    finishFlushIfPossible();
+                } else if (mFlushingAudio == FLUSHING_DECODER_SHUTDOWN
+                        || mFlushingAudio == SHUTTING_DOWN_DECODER) {
+                    mFlushComplete[1 /* audio */][1 /* isDecoder */] = true;
+                    mFlushingAudio = SHUT_DOWN;
+                    finishFlushIfPossible();
+                    needsToCreateAudioDecoder = false;
+                }
+                if (mRenderer == NULL) {
+                    break;
+                }
+                closeAudioSink();
+                mRenderer->flush(
+                        true /* audio */, false /* notifyComplete */);
+                if (mVideoDecoder != NULL) {
+                    mRenderer->flush(
+                            false /* audio */, false /* notifyComplete */);
+                }
+
+                int64_t positionUs;
+                if (!msg->findInt64("positionUs", &positionUs)) {
+                    positionUs = mPreviousSeekTimeUs;
+                }
+                performSeek(positionUs);
+
+                if (reason == Renderer::kDueToError && needsToCreateAudioDecoder) {
+                    instantiateDecoder(true /* audio */, &mAudioDecoder);
+                }
             }
             break;
         }
@@ -2412,12 +2451,7 @@ void NuPlayer::Source::onMessageReceived(const sp<AMessage> & /* msg */) {
     TRESPASS();
 }
 
-//
-// There is a flush from within the decoder's onFlush handling.
-// Without it, it is still possible that a buffer can be queueued
-// after NuPlayer issues a flush on the renderer's audio queue.
-//
-void NuPlayer::performTearDown(const sp<AMessage> &msg) {
+void NuPlayer::tearDownPCMOffload(const sp<AMessage> &msg) {
     int32_t reason;
     CHECK(msg->findInt32("reason", &reason));
 
@@ -2441,14 +2475,13 @@ void NuPlayer::performTearDown(const sp<AMessage> &msg) {
             mDeferredActions.push_back(new SeekAction(positionUs));
             break;
         default:
-            ALOGW("performTearDown while flushing audio in %d", mFlushingAudio);
+            ALOGW("tearDownPCMOffload while flushing audio in %d", mFlushingAudio);
             break;
         }
     }
 
     if (mRenderer != NULL) {
         closeAudioSink();
-        // see comment at beginning of function
         mRenderer->flush(
             true /* audio */, false /* notifyComplete */);
         if (mVideoDecoder != NULL) {

--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
@@ -1143,12 +1143,6 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
                 int32_t reason;
                 CHECK(msg->findInt32("reason", &reason));
                 ALOGV("Tear down audio with reason %d.", reason);
-
-                if (ifDecodedPCMOffload()) {
-                    tearDownPCMOffload(msg);
-                    break;
-                }
-
                 mAudioDecoder.clear();
                 ++mAudioDecoderGeneration;
                 bool needsToCreateAudioDecoder = true;
@@ -2449,47 +2443,6 @@ void NuPlayer::Source::notifyInstantiateSecureDecoders(const sp<AMessage> &reply
 
 void NuPlayer::Source::onMessageReceived(const sp<AMessage> & /* msg */) {
     TRESPASS();
-}
-
-void NuPlayer::tearDownPCMOffload(const sp<AMessage> &msg) {
-    int32_t reason;
-    CHECK(msg->findInt32("reason", &reason));
-
-    if (mAudioDecoder != NULL) {
-        switch (mFlushingAudio) {
-        case NONE:
-        case FLUSHING_DECODER:
-            mDeferredActions.push_back(
-                new FlushDecoderAction(FLUSH_CMD_SHUTDOWN /* audio */,
-                                       FLUSH_CMD_NONE /* video */));
-
-            if (reason == Renderer::kDueToError) {
-                mDeferredActions.push_back(
-                    new InstantiateDecoderAction(true /* audio */, &mAudioDecoder));
-            }
-
-            int64_t positionUs;
-            if (!msg->findInt64("positionUs", &positionUs)) {
-                positionUs = mPreviousSeekTimeUs;
-            }
-            mDeferredActions.push_back(new SeekAction(positionUs));
-            break;
-        default:
-            ALOGW("tearDownPCMOffload while flushing audio in %d", mFlushingAudio);
-            break;
-        }
-    }
-
-    if (mRenderer != NULL) {
-        closeAudioSink();
-        mRenderer->flush(
-            true /* audio */, false /* notifyComplete */);
-        if (mVideoDecoder != NULL) {
-            mRenderer->flush(
-                false /* audio */, false /* notifyComplete */);
-        }
-    }
-    processDeferredActions();
 }
 
 }  // namespace android

--- a/media/libmediaplayerservice/nuplayer/NuPlayer.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayer.h
@@ -300,7 +300,7 @@ protected:
 
     void writeTrackInfo(Parcel* reply, const sp<AMessage> format) const;
 
-    void performTearDown(const sp<AMessage> &msg);
+    void tearDownPCMOffload(const sp<AMessage> &msg);
 
 #ifdef DOLBY_ENABLE
     void onDolbyMessageReceived();

--- a/media/libmediaplayerservice/nuplayer/NuPlayer.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayer.h
@@ -300,8 +300,6 @@ protected:
 
     void writeTrackInfo(Parcel* reply, const sp<AMessage> format) const;
 
-    void tearDownPCMOffload(const sp<AMessage> &msg);
-
 #ifdef DOLBY_ENABLE
     void onDolbyMessageReceived();
 #endif // DOLBY_END

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
@@ -54,6 +54,7 @@
 #include <media/stagefright/MediaErrors.h>
 
 #include <stagefright/AVExtensions.h>
+#include <stagefright/FFMPEGSoftCodec.h>
 #include <gui/Surface.h>
 
 #include "avc_utils.h"
@@ -277,9 +278,16 @@ void NuPlayer::Decoder::onConfigure(const sp<AMessage> &format) {
     ALOGV("[%s] onConfigure (surface=%p)", mComponentName.c_str(), mSurface.get());
 
     mCodec = AVUtils::get()->createCustomComponentByName(mCodecLooper, mime.c_str(), false /* encoder */, format);
+    FFMPEGSoftCodec::overrideComponentName(0, format, &mComponentName, &mime, false);
+
     if (mCodec == NULL) {
-        mCodec = MediaCodec::CreateByType(mCodecLooper, mime.c_str(), false /* encoder */);
+        if (!mComponentName.startsWith(mime.c_str())) {
+            mCodec = MediaCodec::CreateByComponentName(mCodecLooper, mComponentName.c_str());
+        } else {
+            mCodec = MediaCodec::CreateByType(mCodecLooper, mime.c_str(), false /* encoder */);
+        }
     }
+
     int32_t secure = 0;
     if (format->findInt32("secure", &secure) && secure != 0) {
         if (mCodec != NULL) {

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
@@ -621,14 +621,6 @@ bool NuPlayer::Decoder::handleAnOutputBuffer(
     reply->setSize("buffer-ix", index);
     reply->setInt32("generation", mBufferGeneration);
 
-    if ((flags & MediaCodec::BUFFER_FLAG_DATACORRUPT) &&
-            AVNuUtils::get()->dropCorruptFrame()) {
-        ALOGV("[%s] dropping corrupt buffer at time %lld as requested.",
-                     mComponentName.c_str(), (long long)timeUs);
-        reply->post();
-        return true;
-    }
-
     if (eos) {
         ALOGI("[%s] saw output EOS", mIsAudio ? "audio" : "video");
 
@@ -644,6 +636,12 @@ bool NuPlayer::Decoder::handleAnOutputBuffer(
         }
 
         mSkipRenderingUntilMediaTimeUs = -1;
+    } else if ((flags & MediaCodec::BUFFER_FLAG_DATACORRUPT) &&
+            AVNuUtils::get()->dropCorruptFrame()) {
+        ALOGV("[%s] dropping corrupt buffer at time %lld as requested.",
+                     mComponentName.c_str(), (long long)timeUs);
+        reply->post();
+        return true;
     }
 
     mNumFramesTotal += !mIsAudio;

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.cpp
@@ -93,7 +93,6 @@ NuPlayer::Decoder::Decoder(
       mIsSecure(false),
       mFormatChangePending(false),
       mTimeChangePending(false),
-      mPaused(true),
       mResumePending(false),
       mComponentName("decoder") {
     mCodecLooper = new ALooper;

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoder.h
@@ -110,7 +110,6 @@ protected:
     bool mFormatChangePending;
     bool mTimeChangePending;
 
-    bool mPaused;
     bool mResumePending;
     AString mComponentName;
 

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoderBase.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoderBase.h
@@ -36,6 +36,9 @@ struct NuPlayer::DecoderBase : public AHandler {
     void init();
     void setParameters(const sp<AMessage> &params);
 
+    // Synchronous call to ensure decoder will not request or send out data.
+    void pause();
+
     void setRenderer(const sp<Renderer> &renderer);
     virtual status_t setVideoSurface(const sp<Surface> &) { return INVALID_OPERATION; }
 
@@ -78,6 +81,7 @@ protected:
 
     sp<AMessage> mNotify;
     int32_t mBufferGeneration;
+    bool mPaused;
     sp<AMessage> mStats;
 
 private:
@@ -85,6 +89,7 @@ private:
         kWhatConfigure           = 'conf',
         kWhatSetParameters       = 'setP',
         kWhatSetRenderer         = 'setR',
+        kWhatPause               = 'paus',
         kWhatGetInputBuffers     = 'gInB',
         kWhatRequestInputBuffers = 'reqB',
         kWhatFlush               = 'flus',

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.cpp
@@ -48,7 +48,6 @@ NuPlayer::DecoderPassThrough::DecoderPassThrough(
       // The offload read buffer size is 32 KB but 24 KB uses less power.
       mAggregateBufferSizeBytes(24 * 1024),
       mSkipRenderingUntilMediaTimeUs(-1ll),
-      mPaused(false),
       mReachedEOS(true),
       mPendingAudioErr(OK),
       mPendingBuffersToDrain(0),

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.cpp
@@ -213,6 +213,7 @@ sp<ABuffer> NuPlayer::DecoderPassThrough::aggregateBuffer(
     } else {
         // decided not to aggregate
         aggregate = accessUnit;
+        setPcmFormat(aggregate->meta());
     }
 
     return aggregate;

--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.h
@@ -54,7 +54,6 @@ protected:
     sp<Renderer> mRenderer;
     size_t mAggregateBufferSizeBytes;
     int64_t mSkipRenderingUntilMediaTimeUs;
-    bool mPaused;
     bool mReachedEOS;
 
     // Used by feedDecoderInputData to aggregate small buffers into

--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
@@ -26,6 +26,7 @@
 #include <media/stagefright/foundation/AUtils.h>
 #include <media/stagefright/foundation/AWakeLock.h>
 #include <media/stagefright/MediaClock.h>
+#include <media/stagefright/MediaDefs.h>
 #include <media/stagefright/MediaErrors.h>
 #include <media/stagefright/MetaData.h>
 #include <media/stagefright/Utils.h>
@@ -1721,13 +1722,17 @@ status_t NuPlayer::Renderer::onOpenAudioSink(
         channelMask = CHANNEL_MASK_USE_CHANNEL_ORDER;
     }
 
+    int32_t bitWidth = 16;
+    format->findInt32("bit-width", &bitWidth);
+
     int32_t sampleRate;
     CHECK(format->findInt32("sample-rate", &sampleRate));
 
+    AString mime;
+    CHECK(format->findString("mime", &mime));
+
     if (offloadingAudio()) {
         audio_format_t audioFormat = AUDIO_FORMAT_PCM_16_BIT;
-        AString mime;
-        CHECK(format->findString("mime", &mime));
         status_t err = mapMimeToAudioFormat(audioFormat, mime.c_str());
 
         if (err != OK) {
@@ -1735,15 +1740,11 @@ status_t NuPlayer::Renderer::onOpenAudioSink(
                     "audio_format", mime.c_str());
             onDisableOffloadAudio();
         } else {
-            int32_t bitWidth = 16;
-            ALOGV("Mime \"%s\" mapped to audio_format 0x%x",
-                    mime.c_str(), audioFormat);
-
             audioFormat = AVUtils::get()->updateAudioFormat(audioFormat, format);
 
             bitWidth = AVUtils::get()->getAudioSampleBits(format);
             int avgBitRate = -1;
-            format->findInt32("bit-rate", &avgBitRate);
+            format->findInt32("bitrate", &avgBitRate);
 
             int32_t aacProfile = -1;
             if (audioFormat == AUDIO_FORMAT_AAC

--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
@@ -961,7 +961,17 @@ bool NuPlayer::Renderer::onDrainAudioQueue() {
             // (Case 1)
             // Must be a multiple of the frame size.  If it is not a multiple of a frame size, it
             // needs to fail, as we should not carry over fractional frames between calls.
-            CHECK_EQ(copy % mAudioSink->frameSize(), 0);
+
+            if (copy % mAudioSink->frameSize()) {
+                // CHECK_EQ(copy % mAudioSink->frameSize(), 0);
+                ALOGE("CHECK_EQ(copy % mAudioSink->frameSize(), 0) failed b/25372978");
+                ALOGE("mAudioSink->frameSize() %zu", mAudioSink->frameSize());
+                ALOGE("bytes to copy %zu", copy);
+                ALOGE("entry size %zu, entry offset %zu", entry->mBuffer->size(),
+                                                          entry->mOffset - written);
+                notifyEOS(true /*audio*/, UNKNOWN_ERROR);
+                return false;
+            }
 
             // (Case 2, 3, 4)
             // Return early to the caller.

--- a/media/libstagefright/AACExtractor.cpp
+++ b/media/libstagefright/AACExtractor.cpp
@@ -174,7 +174,7 @@ AACExtractor::AACExtractor(
     if (mDataSource->getSize(&streamSize) == OK) {
          while (offset < streamSize) {
             if ((frameSize = getAdtsFrameLength(source, offset, NULL)) == 0) {
-                return;
+                break;
             }
 
             mOffsetVector.push(offset);

--- a/media/libstagefright/AACExtractor.cpp
+++ b/media/libstagefright/AACExtractor.cpp
@@ -136,7 +136,8 @@ AACExtractor::AACExtractor(
         const sp<DataSource> &source, const sp<AMessage> &_meta)
     : mDataSource(source),
       mInitCheck(NO_INIT),
-      mFrameDurationUs(0) {
+      mFrameDurationUs(0),
+      mApeMeta(new MetaData) {
     sp<AMessage> meta = _meta;
 
     if (meta == NULL) {
@@ -170,9 +171,23 @@ AACExtractor::AACExtractor(
     off64_t streamSize, numFrames = 0;
     size_t frameSize = 0;
     int64_t duration = 0;
+    uint8_t apeTag[8];
 
     if (mDataSource->getSize(&streamSize) == OK) {
          while (offset < streamSize) {
+            mDataSource->readAt(offset, &apeTag, 8);
+            if (ape.isAPE(apeTag)) {
+                size_t apeSize = 0;
+                mDataSource->readAt(offset + 8 + 4, &apeSize, 1);
+
+                if (ape.parseAPE(source, offset, mApeMeta) == false) {
+                    break;
+                }
+
+                mOffsetVector.push(offset);
+                offset += apeSize;
+                continue;
+            }
             if ((frameSize = getAdtsFrameLength(source, offset, NULL)) == 0) {
                 break;
             }
@@ -196,15 +211,13 @@ AACExtractor::~AACExtractor() {
 }
 
 sp<MetaData> AACExtractor::getMetaData() {
-    sp<MetaData> meta = new MetaData;
 
     if (mInitCheck != OK) {
-        return meta;
+        return mApeMeta;
     }
+    mApeMeta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_AUDIO_AAC_ADTS);
 
-    meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_AUDIO_AAC_ADTS);
-
-    return meta;
+    return mApeMeta;
 }
 
 size_t AACExtractor::countTracks() {

--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -73,6 +73,10 @@
 #include <OMX_IndexExt.h>
 #include <OMX_AsString.h>
 
+#ifdef USE_SAMSUNG_COLORFORMAT
+#include <sec_format.h>
+#endif
+
 #include "include/avc_utils.h"
 
 #include <stagefright/AVExtensions.h>
@@ -939,12 +943,21 @@ status_t ACodec::setupNativeWindowSizeFormatAndUsage(
     usage |= kVideoGrallocUsage;
     *finalUsage = usage;
 
+#ifdef USE_SAMSUNG_COLORFORMAT
+    OMX_COLOR_FORMATTYPE eNativeColorFormat = def.format.video.eColorFormat;
+    setNativeWindowColorFormat(eNativeColorFormat);
+#endif
+
     ALOGV("gralloc usage: %#x(OMX) => %#x(ACodec)", omxUsage, usage);
     return setNativeWindowSizeFormatAndUsage(
             nativeWindow,
             def.format.video.nFrameWidth,
             def.format.video.nFrameHeight,
+#ifdef USE_SAMSUNG_COLORFORMAT
+            eNativeColorFormat,
+#else
             def.format.video.eColorFormat,
+#endif
             mRotationDegrees,
             usage);
 }
@@ -1274,6 +1287,27 @@ void ACodec::dumpBuffers(OMX_U32 portIndex) {
                 _asString(info.mStatus), info.mStatus, info.mDequeuedAt);
     }
 }
+
+#ifdef USE_SAMSUNG_COLORFORMAT
+void ACodec::setNativeWindowColorFormat(OMX_COLOR_FORMATTYPE &eNativeColorFormat)
+{
+    // In case of Samsung decoders, we set proper native color format for the Native Window
+    if (!strcasecmp(mComponentName.c_str(), "OMX.SEC.AVC.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.SEC.FP.AVC.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.SEC.MPEG4.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.Exynos.AVC.Decoder")) {
+        switch (eNativeColorFormat) {
+            case OMX_COLOR_FormatYUV420SemiPlanar:
+                eNativeColorFormat = (OMX_COLOR_FORMATTYPE)HAL_PIXEL_FORMAT_YCbCr_420_SP;
+                break;
+            case OMX_COLOR_FormatYUV420Planar:
+            default:
+                eNativeColorFormat = (OMX_COLOR_FORMATTYPE)HAL_PIXEL_FORMAT_YCbCr_420_P;
+                break;
+        }
+    }
+}
+#endif
 
 status_t ACodec::cancelBufferToNativeWindow(BufferInfo *info) {
     CHECK_EQ((int)info->mStatus, (int)BufferInfo::OWNED_BY_US);

--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -4213,9 +4213,9 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                     if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11)) {
                         err = FFMPEGSoftCodec::getVideoPortFormat(portIndex,
                                 (int)videoDef->eCompressionFormat, notify, mOMX, mNode);
-                    }
-                    if (err == OK) {
-                        break;
+                        if (err == OK) {
+                            break;
+                        }
                     }
 
                     if (mIsEncoder ^ (portIndex == kPortIndexOutput)) {

--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -63,6 +63,8 @@
 #include <media/stagefright/OMXCodec.h>
 #include <media/stagefright/PersistentSurface.h>
 #include <media/stagefright/SurfaceUtils.h>
+#include <media/stagefright/FFMPEGSoftCodec.h>
+
 #include <media/hardware/HardwareAPI.h>
 
 #include <OMX_AudioExt.h>
@@ -563,7 +565,12 @@ ACodec::ACodec()
 ACodec::~ACodec() {
 }
 
-status_t ACodec::setupCustomCodec(status_t err, const char *, const sp<AMessage> &) {
+status_t ACodec::setupCustomCodec(status_t err, const char *mime, const sp<AMessage> &msg) {
+     if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11) && !mIsEncoder) {
+         return FFMPEGSoftCodec::setAudioFormat(
+               msg, mime, mOMX, mNode);
+     }
+
     return err;
 }
 
@@ -1615,7 +1622,11 @@ status_t ACodec::setComponentRole(
     }
 
     if (i == kNumMimeToRole) {
-        return ERROR_UNSUPPORTED;
+        status_t err = ERROR_UNSUPPORTED;
+        if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11)) {
+            err = FFMPEGSoftCodec::setSupportedRole(mOMX, mNode, isEncoder, mime);
+        }
+        return err;
     }
 
     const char *role =
@@ -1936,7 +1947,8 @@ status_t ACodec::configureCodec(
     if (video) {
         // determine need for software renderer
         bool usingSwRenderer = false;
-        if (haveNativeWindow && mComponentName.startsWith("OMX.google.")) {
+        if (haveNativeWindow && (mComponentName.startsWith("OMX.google.") ||
+                                 mComponentName.startsWith("OMX.ffmpeg."))) {
             usingSwRenderer = true;
             haveNativeWindow = false;
         }
@@ -2021,10 +2033,12 @@ status_t ACodec::configureCodec(
             // and have the decoder figure it all out.
             err = OK;
         } else {
+            int32_t bitsPerSample = 16;
+            msg->findInt32("bit-width", &bitsPerSample);
             err = setupRawAudioFormat(
                     encoder ? kPortIndexInput : kPortIndexOutput,
                     sampleRate,
-                    numChannels);
+                    numChannels, bitsPerSample);
         }
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_AAC)) {
         int32_t numChannels, sampleRate;
@@ -2099,11 +2113,7 @@ status_t ACodec::configureCodec(
             }
             err = setupG711Codec(encoder, sampleRate, numChannels);
         }
-#ifdef QTI_FLAC_DECODER
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_FLAC) && encoder) {
-#else
-    } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_FLAC)) {
-#endif
         int32_t numChannels = 0, sampleRate = 0, compressionLevel = -1;
         if (encoder &&
                 (!msg->findInt32("channel-count", &numChannels)
@@ -2139,16 +2149,21 @@ status_t ACodec::configureCodec(
                 || !msg->findInt32("sample-rate", &sampleRate)) {
             err = INVALID_OPERATION;
         } else {
-            err = setupRawAudioFormat(kPortIndexInput, sampleRate, numChannels);
+            int32_t bitsPerSample = 16;
+            msg->findInt32("bit-width", &bitsPerSample);
+            err = setupRawAudioFormat(kPortIndexInput, sampleRate, numChannels, bitsPerSample);
         }
-    } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_AC3)) {
+    } else if (!strncmp(mComponentName.c_str(), "OMX.google.", 11)
+            && !strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_AC3)) {
         int32_t numChannels;
         int32_t sampleRate;
         if (!msg->findInt32("channel-count", &numChannels)
                 || !msg->findInt32("sample-rate", &sampleRate)) {
             err = INVALID_OPERATION;
         } else {
-            err = setupAC3Codec(encoder, numChannels, sampleRate);
+            int32_t bitsPerSample = 16;
+            msg->findInt32("bit-width", &bitsPerSample);
+            err = setupAC3Codec(encoder, numChannels, sampleRate, bitsPerSample);
         }
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_EAC3)) {
         int32_t numChannels;
@@ -2157,7 +2172,9 @@ status_t ACodec::configureCodec(
                 || !msg->findInt32("sample-rate", &sampleRate)) {
             err = INVALID_OPERATION;
         } else {
-            err = setupEAC3Codec(encoder, numChannels, sampleRate);
+            int32_t bitsPerSample = 16;
+            msg->findInt32("bit-width", &bitsPerSample);
+            err = setupEAC3Codec(encoder, numChannels, sampleRate, bitsPerSample);
         }
     } else {
         err = setupCustomCodec(err, mime, msg);
@@ -2474,9 +2491,9 @@ status_t ACodec::setupAACCodec(
 }
 
 status_t ACodec::setupAC3Codec(
-        bool encoder, int32_t numChannels, int32_t sampleRate) {
+        bool encoder, int32_t numChannels, int32_t sampleRate, int32_t bitsPerSample) {
     status_t err = setupRawAudioFormat(
-            encoder ? kPortIndexInput : kPortIndexOutput, sampleRate, numChannels);
+            encoder ? kPortIndexInput : kPortIndexOutput, sampleRate, numChannels, bitsPerSample);
 
     if (err != OK) {
         return err;
@@ -2512,9 +2529,9 @@ status_t ACodec::setupAC3Codec(
 }
 
 status_t ACodec::setupEAC3Codec(
-        bool encoder, int32_t numChannels, int32_t sampleRate) {
+        bool encoder, int32_t numChannels, int32_t sampleRate, int32_t bitsPerSample) {
     status_t err = setupRawAudioFormat(
-            encoder ? kPortIndexInput : kPortIndexOutput, sampleRate, numChannels);
+            encoder ? kPortIndexInput : kPortIndexOutput, sampleRate, numChannels, bitsPerSample);
 
     if (err != OK) {
         return err;
@@ -2660,7 +2677,7 @@ status_t ACodec::setupFlacCodec(
 }
 
 status_t ACodec::setupRawAudioFormat(
-        OMX_U32 portIndex, int32_t sampleRate, int32_t numChannels) {
+        OMX_U32 portIndex, int32_t sampleRate, int32_t numChannels, int32_t bitsPerSample) {
     OMX_PARAM_PORTDEFINITIONTYPE def;
     InitOMXParams(&def);
     def.nPortIndex = portIndex;
@@ -2695,7 +2712,7 @@ status_t ACodec::setupRawAudioFormat(
     pcmParams.nChannels = numChannels;
     pcmParams.eNumData = OMX_NumericalDataSigned;
     pcmParams.bInterleaved = OMX_TRUE;
-    pcmParams.nBitPerSample = 16;
+    pcmParams.nBitPerSample = bitsPerSample;
     pcmParams.nSamplingRate = sampleRate;
     pcmParams.ePCMMode = OMX_AUDIO_PCMModeLinear;
 
@@ -2922,7 +2939,13 @@ status_t ACodec::setupVideoDecoder(
     status_t err = GetVideoCodingTypeFromMime(mime, &compressionFormat);
 
     if (err != OK) {
-        return err;
+        if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11)) {
+            err = FFMPEGSoftCodec::setVideoFormat(
+                    msg, mime, mOMX, mNode, mIsEncoder, &compressionFormat);
+        }
+        if (err != OK) {
+            return err;
+        }
     }
 
     err = setVideoPortFormatType(
@@ -3072,7 +3095,14 @@ status_t ACodec::setupVideoEncoder(const char *mime, const sp<AMessage> &msg) {
     err = GetVideoCodingTypeFromMime(mime, &compressionFormat);
 
     if (err != OK) {
-        return err;
+        if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11)) {
+            err = FFMPEGSoftCodec::setVideoFormat(
+                    msg, mime, mOMX, mNode, mIsEncoder, &compressionFormat);
+        }
+        if (err != OK) {
+            ALOGE("Not a supported video mime type: %s", mime);
+            return err;
+        }
     }
 
     err = setVideoPortFormatType(
@@ -4180,6 +4210,14 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
 
                 default:
                 {
+                    if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11)) {
+                        err = FFMPEGSoftCodec::getVideoPortFormat(portIndex,
+                                (int)videoDef->eCompressionFormat, notify, mOMX, mNode);
+                    }
+                    if (err == OK) {
+                        break;
+                    }
+
                     if (mIsEncoder ^ (portIndex == kPortIndexOutput)) {
                         // should be CodingUnused
                         ALOGE("Raw port video compression format is %s(%d)",
@@ -4226,7 +4264,9 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                     if (params.nChannels <= 0
                             || (params.nChannels != 1 && !params.bInterleaved)
                             || (params.nBitPerSample != 16u
-                                    && params.nBitPerSample != 24u)// we support 16/24 bit s/w decoding
+                                    && params.nBitPerSample != 24u
+                                    && params.nBitPerSample != 32u
+                                    && params.nBitPerSample != 8u)// we support 8/16/24/32 bit s/w decoding
                             || params.eNumData != OMX_NumericalDataSigned
                             || params.ePCMMode != OMX_AUDIO_PCMModeLinear) {
                         ALOGE("unsupported PCM port: %u channels%s, %u-bit, %s(%d), %s(%d) mode ",
@@ -4242,6 +4282,7 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                     notify->setInt32("channel-count", params.nChannels);
                     notify->setInt32("sample-rate", params.nSamplingRate);
                     notify->setInt32("bit-width", params.nBitPerSample);
+
                     if (mChannelMaskPresent) {
                         notify->setInt32("channel-mask", mChannelMask);
                     }
@@ -4291,6 +4332,7 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
 
                 case OMX_AUDIO_CodingFLAC:
                 {
+                    if (portIndex == kPortIndexInput) {
                     OMX_AUDIO_PARAM_FLACTYPE params;
                     InitOMXParams(&params);
                     params.nPortIndex = portIndex;
@@ -4305,6 +4347,7 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                     notify->setInt32("channel-count", params.nChannels);
                     notify->setInt32("sample-rate", params.nSampleRate);
                     break;
+                    }
                 }
 
                 case OMX_AUDIO_CodingMP3:
@@ -4445,6 +4488,14 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                 }
 
                 default:
+                    if (!strncmp(mComponentName.c_str(), "OMX.ffmpeg.", 11)) {
+                        err = FFMPEGSoftCodec::getAudioPortFormat(portIndex,
+                                (int)audioDef->eEncoding, notify, mOMX, mNode);
+                    }
+                    if (err == OK) {
+                        break;
+                    }
+
                     ALOGE("Unsupported audio coding: %s(%d)\n",
                             asString(audioDef->eEncoding), audioDef->eEncoding);
                     return BAD_TYPE;
@@ -5753,8 +5804,79 @@ bool ACodec::LoadedState::onConfigureComponent(
         ALOGE("[%s] configureCodec returning error %d",
               mCodec->mComponentName.c_str(), err);
 
-        mCodec->signalError(OMX_ErrorUndefined, makeNoSideEffectStatus(err));
-        return false;
+        int32_t encoder;
+        if (!msg->findInt32("encoder", &encoder)) {
+            encoder = false;
+        }
+
+        if (!encoder && !strncmp(mime.c_str(), "video/", strlen("video/"))) {
+            Vector<OMXCodec::CodecNameAndQuirks> matchingCodecs;
+
+            OMXCodec::findMatchingCodecs(
+                mime.c_str(),
+                encoder, // createEncoder
+                NULL,  // matchComponentName
+                0,     // flags
+                &matchingCodecs);
+
+            status_t err = mCodec->mOMX->freeNode(mCodec->mNode);
+
+            if (err != OK) {
+                ALOGE("Failed to freeNode");
+                mCodec->signalError(OMX_ErrorUndefined, makeNoSideEffectStatus(err));
+                return false;
+            }
+
+            mCodec->mNode = 0;
+            AString componentName;
+            sp<CodecObserver> observer = new CodecObserver;
+
+            err = NAME_NOT_FOUND;
+            for (size_t matchIndex = 0; matchIndex < matchingCodecs.size();
+                    ++matchIndex) {
+                componentName = matchingCodecs.itemAt(matchIndex).mName.string();
+                if (!strcmp(mCodec->mComponentName.c_str(), componentName.c_str())) {
+                    continue;
+                }
+
+                pid_t tid = gettid();
+                int prevPriority = androidGetThreadPriority(tid);
+                androidSetThreadPriority(tid, ANDROID_PRIORITY_FOREGROUND);
+                err = mCodec->mOMX->allocateNode(componentName.c_str(), observer, &mCodec->mNode);
+                androidSetThreadPriority(tid, prevPriority);
+
+                if (err == OK) {
+                    break;
+                } else {
+                    ALOGW("Allocating component '%s' failed, try next one.", componentName.c_str());
+                }
+
+                mCodec->mNode = 0;
+            }
+
+            if (mCodec->mNode == 0) {
+                if (!mime.empty()) {
+                    ALOGE("Unable to instantiate a %scoder for type '%s' with err %#x.",
+                            encoder ? "en" : "de", mime.c_str(), err);
+                } else {
+                    ALOGE("Unable to instantiate codec '%s' with err %#x.", componentName.c_str(), err);
+                }
+
+                mCodec->signalError((OMX_ERRORTYPE)err, makeNoSideEffectStatus(err));
+                return false;
+            }
+
+            sp<AMessage> notify = new AMessage(kWhatOMXMessageList, mCodec);
+            observer->setNotificationMessage(notify);
+            mCodec->mComponentName = componentName;
+
+            err = mCodec->configureCodec(mime.c_str(), msg);
+
+            if (err != OK) {
+                mCodec->signalError((OMX_ERRORTYPE)err, makeNoSideEffectStatus(err));
+                return false;
+            }
+        }
     }
 
     {

--- a/media/libstagefright/APE.cpp
+++ b/media/libstagefright/APE.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) Texas Instruments - http://www.ti.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "APE_TAG"
+#include <utils/Log.h>
+
+#include "include/APE.h"
+
+namespace android {
+
+APE::APE(){
+
+}
+
+APE::~APE(){
+
+}
+
+bool APE::isAPE(uint8_t *apeTag) const {
+    if(apeTag[0] == 'A' && apeTag[1] == 'P' && apeTag[2] == 'E' &&
+        apeTag[3] == 'T' && apeTag[4] == 'A' && apeTag[5] == 'G' &&
+        apeTag[6] == 'E' && apeTag[7] == 'X'){
+        return true;
+    }
+    return false;
+}
+
+size_t sizeItemKey(const sp<DataSource> &source, off64_t offset){
+    off64_t ItemKeyOffset = offset;
+    uint8_t keyTerminator = 0;
+    size_t keySize = 0;
+    while (keyTerminator != 0){
+        source->readAt(ItemKeyOffset, &keyTerminator, 1);
+        ItemKeyOffset++;
+        keySize++;
+    }
+    return keySize - 1;
+}
+
+bool APE::parseAPE(const sp<DataSource> &source, off64_t offset,
+        sp<MetaData> &meta){
+
+    struct Map {
+            int key;
+            const char *tag;
+    } const kMap[] = {
+            { kKeyAlbum, "Album" },
+            { kKeyArtist, "Artist" },
+            { kKeyAlbumArtist, "Album" },
+            { kKeyComposer, "Composer" },
+            { kKeyGenre, "Genre" },
+            { kKeyTitle, "Title" },
+            { kKeyYear, "Year" },
+            { kKeyCDTrackNumber, "Track" },
+            { kKeyDate, "Record Date"},
+    };
+
+    static const size_t kNumMapEntries = sizeof(kMap) / sizeof(kMap[0]);
+
+    off64_t headerOffset = offset;
+    headerOffset += 16;
+    itemNumber = 0;
+    if (source->readAt(headerOffset, &itemNumber, 1) == 0)
+        return false;
+
+    headerOffset += 16;
+
+    for(uint32_t it = 0; it < itemNumber; it++){
+        lenValue = 0;
+        if (source->readAt(headerOffset, &lenValue, 1) == 0)
+            return false;
+
+        headerOffset += 4;
+
+        itemFlags = 0;
+        if (source->readAt(headerOffset, &itemFlags, 1) == 0)
+            return false;
+
+        headerOffset += 4;
+
+        size_t sizeKey = sizeItemKey(source, headerOffset);
+
+        char *key = new char[sizeKey];
+
+        if (source->readAt(headerOffset, key, sizeKey) == 0)
+            return false;
+
+        key[sizeKey] = '\0';
+        headerOffset += sizeKey + 1;
+
+        char *val = new char[lenValue + 1];
+
+        if (source->readAt(headerOffset, val, lenValue) == 0)
+            return false;
+
+        val[lenValue] = '\0';
+
+        for (size_t i = 0; i < kNumMapEntries; i++){
+            if (!strcmp(key, kMap[i].tag)){
+                if (itemFlags == 0)
+                    meta->setCString(kMap[i].key, (const char *)val);
+                break;
+            }
+        }
+        headerOffset += lenValue;
+        delete[] key;
+        delete[] val;
+    }
+
+    return true;
+}
+} //namespace android

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -156,9 +156,6 @@ LOCAL_CLANG := true
 # FFMPEG plugin
 LOCAL_C_INCLUDES += $(TOP)/external/stagefright-plugins/include
 
-# FFMPEG plugin
-LOCAL_C_INCLUDES += $(TOP)/external/stagefright-plugins/include
-
 #LOCAL_CFLAGS += -DLOG_NDEBUG=0
 
 ifeq ($(BOARD_USE_SAMSUNG_COLORFORMAT), true)

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -156,6 +156,20 @@ LOCAL_CLANG := true
 # FFMPEG plugin
 LOCAL_C_INCLUDES += $(TOP)/external/stagefright-plugins/include
 
+# FFMPEG plugin
+LOCAL_C_INCLUDES += $(TOP)/external/stagefright-plugins/include
+
+#LOCAL_CFLAGS += -DLOG_NDEBUG=0
+
+ifeq ($(BOARD_USE_SAMSUNG_COLORFORMAT), true)
+LOCAL_CFLAGS += -DUSE_SAMSUNG_COLORFORMAT
+
+# Include native color format header path
+LOCAL_C_INCLUDES += \
+	$(TOP)/hardware/samsung/exynos4/hal/include \
+	$(TOP)/hardware/samsung/exynos4/include
+endif
+
 LOCAL_MODULE:= libstagefright
 
 LOCAL_MODULE_TAGS := optional

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -69,6 +69,7 @@ LOCAL_SRC_FILES:=                         \
         WVMExtractor.cpp                  \
         XINGSeeker.cpp                    \
         avc_utils.cpp                     \
+        APE.cpp                           \
 
 LOCAL_C_INCLUDES:= \
         $(TOP)/frameworks/av/include/media/ \

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -134,7 +134,7 @@ LOCAL_SHARED_LIBRARIES += \
 LOCAL_CFLAGS += -Wno-multichar -Werror -Wno-error=deprecated-declarations -Wall
 
 ifeq ($(TARGET_USES_QCOM_BSP), true)
-    LOCAL_C_INCLUDES += hardware/qcom/display/libgralloc
+    LOCAL_C_INCLUDES += $(call project-path-for,qcom-display)/libgralloc
     LOCAL_CFLAGS += -DQTI_BSP
 endif
 

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -70,6 +70,7 @@ LOCAL_SRC_FILES:=                         \
         XINGSeeker.cpp                    \
         avc_utils.cpp                     \
         APE.cpp                           \
+        FFMPEGSoftCodec.cpp               \
 
 LOCAL_C_INCLUDES:= \
         $(TOP)/frameworks/av/include/media/ \
@@ -151,6 +152,9 @@ endif
 endif
 
 LOCAL_CLANG := true
+
+# FFMPEG plugin
+LOCAL_C_INCLUDES += $(TOP)/external/stagefright-plugins/include
 
 LOCAL_MODULE:= libstagefright
 

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -73,6 +73,7 @@ LOCAL_SRC_FILES:=                         \
 LOCAL_C_INCLUDES:= \
         $(TOP)/frameworks/av/include/media/ \
         $(TOP)/frameworks/av/media/libavextensions \
+        $(TOP)/frameworks/av/media/libstagefright/mpeg2ts \
         $(TOP)/frameworks/av/include/media/stagefright/timedtext \
         $(TOP)/frameworks/native/include/media/hardware \
         $(TOP)/frameworks/native/include/media/openmax \

--- a/media/libstagefright/CameraSource.cpp
+++ b/media/libstagefright/CameraSource.cpp
@@ -114,7 +114,12 @@ static int32_t getColorFormat(const char* colorFormat) {
     }
 
     if (!strcmp(colorFormat, CameraParameters::PIXEL_FORMAT_YUV420SP)) {
+#ifdef USE_SAMSUNG_COLORFORMAT
+        static const int OMX_SEC_COLOR_FormatNV12LPhysicalAddress = 0x7F000002;
+        return OMX_SEC_COLOR_FormatNV12LPhysicalAddress;
+#else
         return OMX_COLOR_FormatYUV420SemiPlanar;
+#endif
     }
 
     if (!strcmp(colorFormat, CameraParameters::PIXEL_FORMAT_YUV422I)) {

--- a/media/libstagefright/DataSource.cpp
+++ b/media/libstagefright/DataSource.cpp
@@ -112,29 +112,42 @@ status_t DataSource::getSize(off64_t *size) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Mutex DataSource::gSnifferMutex;
-List<DataSource::SnifferFunc> DataSource::gSniffers;
-bool DataSource::gSniffersRegistered = false;
-
 bool DataSource::sniff(
         String8 *mimeType, float *confidence, sp<AMessage> *meta) {
+
+    return  mSniffer->sniff(this, mimeType, confidence, meta);
+}
+
+// static
+void DataSource::RegisterSniffer_l(SnifferFunc func) {
+    return;
+}
+
+// static
+void DataSource::RegisterDefaultSniffers() {
+    return;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Sniffer::Sniffer() {
+    registerDefaultSniffers();
+}
+
+bool Sniffer::sniff(
+        DataSource *source, String8 *mimeType, float *confidence, sp<AMessage> *meta) {
+
     *mimeType = "";
     *confidence = 0.0f;
     meta->clear();
 
-    {
-        Mutex::Autolock autoLock(gSnifferMutex);
-        if (!gSniffersRegistered) {
-            return false;
-        }
-    }
-
-    for (List<SnifferFunc>::iterator it = gSniffers.begin();
-         it != gSniffers.end(); ++it) {
+    Mutex::Autolock autoLock(mSnifferMutex);
+    for (List<SnifferFunc>::iterator it = mSniffers.begin();
+         it != mSniffers.end(); ++it) {
         String8 newMimeType;
         float newConfidence;
         sp<AMessage> newMeta;
-        if ((*it)(this, &newMimeType, &newConfidence, &newMeta)) {
+        if ((*it)(source, &newMimeType, &newConfidence, &newMeta)) {
             if (newConfidence > *confidence) {
                 *mimeType = newMimeType;
                 *confidence = newConfidence;
@@ -146,45 +159,40 @@ bool DataSource::sniff(
     return *confidence > 0.0;
 }
 
-// static
-void DataSource::RegisterSniffer_l(SnifferFunc func) {
-    for (List<SnifferFunc>::iterator it = gSniffers.begin();
-         it != gSniffers.end(); ++it) {
+void Sniffer::registerSniffer_l(SnifferFunc func) {
+
+    for (List<SnifferFunc>::iterator it = mSniffers.begin();
+         it != mSniffers.end(); ++it) {
         if (*it == func) {
             return;
         }
     }
 
-    gSniffers.push_back(func);
+    mSniffers.push_back(func);
 }
 
-// static
-void DataSource::RegisterDefaultSniffers() {
-    Mutex::Autolock autoLock(gSnifferMutex);
-    if (gSniffersRegistered) {
-        return;
-    }
+void Sniffer::registerDefaultSniffers() {
+    Mutex::Autolock autoLock(mSnifferMutex);
 
-    RegisterSniffer_l(SniffMPEG4);
-    RegisterSniffer_l(SniffMatroska);
-    RegisterSniffer_l(SniffOgg);
-    RegisterSniffer_l(SniffWAV);
-    RegisterSniffer_l(SniffFLAC);
-    RegisterSniffer_l(SniffAMR);
-    RegisterSniffer_l(SniffMPEG2TS);
-    RegisterSniffer_l(SniffMP3);
-    RegisterSniffer_l(SniffAAC);
-    RegisterSniffer_l(SniffMPEG2PS);
-    RegisterSniffer_l(SniffWVM);
+    registerSniffer_l(SniffMPEG4);
+    registerSniffer_l(SniffMatroska);
+    registerSniffer_l(SniffOgg);
+    registerSniffer_l(SniffWAV);
+    registerSniffer_l(SniffFLAC);
+    registerSniffer_l(SniffAMR);
+    registerSniffer_l(SniffMPEG2TS);
+    registerSniffer_l(SniffMP3);
+    registerSniffer_l(SniffAAC);
+    registerSniffer_l(SniffMPEG2PS);
+    registerSniffer_l(SniffWVM);
     RegisterSniffer_l(SniffMidi);
     RegisterSniffer_l(AVUtils::get()->getExtendedSniffer());
 
     char value[PROPERTY_VALUE_MAX];
     if (property_get("drm.service.enabled", value, NULL)
             && (!strcmp(value, "1") || !strcasecmp(value, "true"))) {
-        RegisterSniffer_l(SniffDRM);
+        registerSniffer_l(SniffDRM);
     }
-    gSniffersRegistered = true;
 }
 
 // static

--- a/media/libstagefright/DataSource.cpp
+++ b/media/libstagefright/DataSource.cpp
@@ -47,10 +47,27 @@
 #include <utils/String8.h>
 
 #include <cutils/properties.h>
+#include <cutils/log.h>
+
+#include <dlfcn.h>
 
 #include <stagefright/AVExtensions.h>
 
 namespace android {
+
+static void *loadExtractorPlugin() {
+    void *ret = NULL;
+    char lib[PROPERTY_VALUE_MAX];
+    if (property_get("media.sf.extractor-plugin", lib, NULL)) {
+        if (void *extractorLib = ::dlopen(lib, RTLD_LAZY)) {
+            ret = ::dlsym(extractorLib, "getExtractorPlugin");
+            ALOGW_IF(!ret, "Failed to find symbol, dlerror: %s", ::dlerror());
+        } else {
+            ALOGV("Failed to load %s, dlerror: %s", lib, ::dlerror());
+        }
+    }
+    return ret;
+}
 
 bool DataSource::getUInt16(off64_t offset, uint16_t *x) {
     *x = 0;
@@ -119,7 +136,7 @@ bool DataSource::sniff(
 }
 
 // static
-void DataSource::RegisterSniffer_l(SnifferFunc func) {
+void DataSource::RegisterSniffer_l(SnifferFunc /* func */) {
     return;
 }
 
@@ -136,6 +153,13 @@ Sniffer::Sniffer() {
 
 bool Sniffer::sniff(
         DataSource *source, String8 *mimeType, float *confidence, sp<AMessage> *meta) {
+
+    bool forceExtraSniffers = false;
+
+    if (*confidence == 3.14f) {
+       // Magic value, as set by MediaExtractor when a video container looks incomplete
+       forceExtraSniffers = true;
+    }
 
     *mimeType = "";
     *confidence = 0.0f;
@@ -156,6 +180,23 @@ bool Sniffer::sniff(
         }
     }
 
+    /* Only do the deeper sniffers if the results are null or in doubt */
+    if (mimeType->length() == 0 || *confidence < 0.21f || forceExtraSniffers) {
+        for (List<SnifferFunc>::iterator it = mExtraSniffers.begin();
+                it != mExtraSniffers.end(); ++it) {
+            String8 newMimeType;
+            float newConfidence;
+            sp<AMessage> newMeta;
+            if ((*it)(source, &newMimeType, &newConfidence, &newMeta)) {
+                if (newConfidence > *confidence) {
+                    *mimeType = newMimeType;
+                    *confidence = newConfidence;
+                    *meta = newMeta;
+                }
+            }
+        }
+    }
+
     return *confidence > 0.0;
 }
 
@@ -169,6 +210,26 @@ void Sniffer::registerSniffer_l(SnifferFunc func) {
     }
 
     mSniffers.push_back(func);
+}
+
+void Sniffer::registerSnifferPlugin() {
+    static void (*getExtractorPlugin)(MediaExtractor::Plugin *) =
+            (void (*)(MediaExtractor::Plugin *))loadExtractorPlugin();
+
+    MediaExtractor::Plugin *plugin = MediaExtractor::getPlugin();
+    if (!plugin->sniff && getExtractorPlugin) {
+        getExtractorPlugin(plugin);
+    }
+    if (plugin->sniff) {
+        for (List<SnifferFunc>::iterator it = mExtraSniffers.begin();
+             it != mExtraSniffers.end(); ++it) {
+            if (*it == plugin->sniff) {
+                return;
+            }
+        }
+
+        mExtraSniffers.push_back(plugin->sniff);
+    }
 }
 
 void Sniffer::registerDefaultSniffers() {
@@ -185,8 +246,9 @@ void Sniffer::registerDefaultSniffers() {
     registerSniffer_l(SniffAAC);
     registerSniffer_l(SniffMPEG2PS);
     registerSniffer_l(SniffWVM);
-    RegisterSniffer_l(SniffMidi);
-    RegisterSniffer_l(AVUtils::get()->getExtendedSniffer());
+    registerSniffer_l(SniffMidi);
+    registerSniffer_l(AVUtils::get()->getExtendedSniffer());
+    registerSnifferPlugin();
 
     char value[PROPERTY_VALUE_MAX];
     if (property_get("drm.service.enabled", value, NULL)

--- a/media/libstagefright/FFMPEGSoftCodec.cpp
+++ b/media/libstagefright/FFMPEGSoftCodec.cpp
@@ -1,0 +1,1149 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_NDEBUG 0
+#define LOG_TAG "FFMPEGSoftCodec"
+#include <utils/Log.h>
+
+#include <media/stagefright/foundation/ADebug.h>
+#include <media/stagefright/foundation/AMessage.h>
+#include <media/stagefright/foundation/ABuffer.h>
+#include <media/stagefright/foundation/ABitReader.h>
+
+#include <media/stagefright/FFMPEGSoftCodec.h>
+
+#include <media/stagefright/MediaDefs.h>
+#include <media/stagefright/MediaCodecList.h>
+#include <media/stagefright/MetaData.h>
+#include <media/stagefright/OMXCodec.h>
+#include <media/stagefright/Utils.h>
+
+#include <OMX_Component.h>
+#include <OMX_AudioExt.h>
+#include <OMX_IndexExt.h>
+
+#include <OMX_FFMPEG_Extn.h>
+
+namespace android {
+
+enum MetaKeyType{
+    INT32, INT64, STRING, DATA, CSD
+};
+
+struct MetaKeyEntry{
+    int MetaKey;
+    const char* MsgKey;
+    MetaKeyType KeyType;
+};
+
+static const MetaKeyEntry MetaKeyTable[] {
+   {kKeyAACAOT               , "aac-profile"            , INT32},
+   {kKeyArbitraryMode        , "use-arbitrary-mode"     , INT32},
+   {kKeyBitRate              , "bitrate"                , INT32},
+   {kKeyBitsPerSample        , "bit-width"              , INT32},
+   {kKeyBlockAlign           , "block-align"            , INT32},
+   {kKeyChannelCount         , "channel-count"          , INT32},
+   {kKeyCodecId              , "codec-id"               , INT32},
+   {kKeyCodedSampleBits      , "coded-sample-bits"      , INT32},
+   {kKeyRawCodecSpecificData , "raw-codec-specific-data", CSD},
+   {kKeyRVVersion            , "rv-version"             , INT32},
+   {kKeySampleFormat         , "sample-format"          , INT32},
+   {kKeySampleRate           , "sample-rate"            , INT32},
+   {kKeyWMAVersion           , "wma-version"            , INT32},  // int32_t
+   {kKeyWMVVersion           , "wmv-version"            , INT32},
+   {kKeyPCMFormat            , "pcm-format"             , INT32},
+};
+
+const char* FFMPEGSoftCodec::getMsgKey(int key) {
+    static const size_t numMetaKeys =
+                     sizeof(MetaKeyTable) / sizeof(MetaKeyTable[0]);
+    size_t i;
+    for (i = 0; i < numMetaKeys; ++i) {
+        if (key == MetaKeyTable[i].MetaKey) {
+            return MetaKeyTable[i].MsgKey;
+        }
+    }
+    return "unknown";
+}
+
+void FFMPEGSoftCodec::convertMetaDataToMessageFF(
+        const sp<MetaData> &meta, sp<AMessage> *format) {
+    const char * str_val;
+    int32_t int32_val;
+    int64_t int64_val;
+    uint32_t data_type;
+    const void * data;
+    size_t size;
+    static const size_t numMetaKeys =
+                     sizeof(MetaKeyTable) / sizeof(MetaKeyTable[0]);
+    size_t i;
+    for (i = 0; i < numMetaKeys; ++i) {
+        if (MetaKeyTable[i].KeyType == INT32 &&
+            meta->findInt32(MetaKeyTable[i].MetaKey, &int32_val)) {
+            ALOGV("found metakey %s of type int32", MetaKeyTable[i].MsgKey);
+            format->get()->setInt32(MetaKeyTable[i].MsgKey, int32_val);
+        } else if (MetaKeyTable[i].KeyType == INT64 &&
+                 meta->findInt64(MetaKeyTable[i].MetaKey, &int64_val)) {
+            ALOGV("found metakey %s of type int64", MetaKeyTable[i].MsgKey);
+            format->get()->setInt64(MetaKeyTable[i].MsgKey, int64_val);
+        } else if (MetaKeyTable[i].KeyType == STRING &&
+                 meta->findCString(MetaKeyTable[i].MetaKey, &str_val)) {
+            ALOGV("found metakey %s of type string", MetaKeyTable[i].MsgKey);
+            format->get()->setString(MetaKeyTable[i].MsgKey, str_val);
+        } else if ( (MetaKeyTable[i].KeyType == DATA ||
+                   MetaKeyTable[i].KeyType == CSD) &&
+                   meta->findData(MetaKeyTable[i].MetaKey, &data_type, &data, &size)) {
+            ALOGV("found metakey %s of type data", MetaKeyTable[i].MsgKey);
+            if (MetaKeyTable[i].KeyType == CSD) {
+                const char *mime;
+                CHECK(meta->findCString(kKeyMIMEType, &mime));
+                if (strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_AVC)) {
+                    sp<ABuffer> buffer = new ABuffer(size);
+                    memcpy(buffer->data(), data, size);
+                    buffer->meta()->setInt32("csd", true);
+                    buffer->meta()->setInt64("timeUs", 0);
+                    format->get()->setBuffer("csd-0", buffer);
+                } else {
+                    const uint8_t *ptr = (const uint8_t *)data;
+                    CHECK(size >= 8);
+                    int seqLength = 0, picLength = 0;
+                    for (size_t i = 4; i < (size - 4); i++)
+                    {
+                        if ((*(ptr + i) == 0) && (*(ptr + i + 1) == 0) &&
+                           (*(ptr + i + 2) == 0) && (*(ptr + i + 3) == 1))
+                            seqLength = i;
+                    }
+                    sp<ABuffer> buffer = new ABuffer(seqLength);
+                    memcpy(buffer->data(), data, seqLength);
+                    buffer->meta()->setInt32("csd", true);
+                    buffer->meta()->setInt64("timeUs", 0);
+                    format->get()->setBuffer("csd-0", buffer);
+                    picLength=size-seqLength;
+                    sp<ABuffer> buffer1 = new ABuffer(picLength);
+                    memcpy(buffer1->data(), (const uint8_t *)data + seqLength, picLength);
+                    buffer1->meta()->setInt32("csd", true);
+                    buffer1->meta()->setInt64("timeUs", 0);
+                    format->get()->setBuffer("csd-1", buffer1);
+                }
+            } else {
+                sp<ABuffer> buffer = new ABuffer(size);
+                memcpy(buffer->data(), data, size);
+                format->get()->setBuffer(MetaKeyTable[i].MsgKey, buffer);
+            }
+        }
+
+    }
+}
+
+void FFMPEGSoftCodec::convertMessageToMetaDataFF(
+        const sp<AMessage> &msg, sp<MetaData> &meta) {
+    AString str_val;
+    int32_t int32_val;
+    int64_t int64_val;
+    static const size_t numMetaKeys =
+                     sizeof(MetaKeyTable) / sizeof(MetaKeyTable[0]);
+    size_t i;
+    for (i = 0; i < numMetaKeys; ++i) {
+        if (MetaKeyTable[i].KeyType == INT32 &&
+                msg->findInt32(MetaKeyTable[i].MsgKey, &int32_val)) {
+            ALOGV("found metakey %s of type int32", MetaKeyTable[i].MsgKey);
+            meta->setInt32(MetaKeyTable[i].MetaKey, int32_val);
+        } else if (MetaKeyTable[i].KeyType == INT64 &&
+                msg->findInt64(MetaKeyTable[i].MsgKey, &int64_val)) {
+            ALOGV("found metakey %s of type int64", MetaKeyTable[i].MsgKey);
+            meta->setInt64(MetaKeyTable[i].MetaKey, int64_val);
+        } else if (MetaKeyTable[i].KeyType == STRING &&
+                msg->findString(MetaKeyTable[i].MsgKey, &str_val)) {
+            ALOGV("found metakey %s of type string", MetaKeyTable[i].MsgKey);
+            meta->setCString(MetaKeyTable[i].MetaKey, str_val.c_str());
+        }
+    }
+}
+
+
+template<class T>
+static void InitOMXParams(T *params) {
+    params->nSize = sizeof(T);
+    params->nVersion.s.nVersionMajor = 1;
+    params->nVersion.s.nVersionMinor = 0;
+    params->nVersion.s.nRevision = 0;
+    params->nVersion.s.nStep = 0;
+}
+
+void FFMPEGSoftCodec::overrideComponentName(
+        uint32_t /*quirks*/, const sp<AMessage> &msg, AString* componentName, AString* mime, int32_t isEncoder) {
+
+    int32_t wmvVersion = 0;
+    if (!strncasecmp(mime->c_str(), MEDIA_MIMETYPE_VIDEO_WMV, strlen(MEDIA_MIMETYPE_VIDEO_WMV)) &&
+            msg->findInt32(getMsgKey(kKeyWMVVersion), &wmvVersion)) {
+        ALOGD("Found WMV version key %d", wmvVersion);
+        if (wmvVersion == 1) {
+            ALOGD("Use FFMPEG for unsupported WMV track");
+            componentName->setTo("OMX.ffmpeg.wmv.decoder");
+        }
+    }
+
+    int32_t encodeOptions = 0;
+    if (!isEncoder && !strncasecmp(mime->c_str(), MEDIA_MIMETYPE_AUDIO_WMA, strlen(MEDIA_MIMETYPE_AUDIO_WMA)) &&
+            !msg->findInt32(getMsgKey(kKeyWMAEncodeOpt), &encodeOptions)) {
+        ALOGD("Use FFMPEG for unsupported WMA track");
+        componentName->setTo("OMX.ffmpeg.wma.decoder");
+    }
+
+    // Google's decoder doesn't support MAIN profile
+    int32_t aacProfile = 0;
+    if (!isEncoder && !strncasecmp(mime->c_str(), MEDIA_MIMETYPE_AUDIO_AAC, strlen(MEDIA_MIMETYPE_AUDIO_AAC)) &&
+            msg->findInt32(getMsgKey(kKeyAACAOT), &aacProfile)) {
+        if (aacProfile == OMX_AUDIO_AACObjectMain) {
+            ALOGD("Use FFMPEG for AAC MAIN profile");
+            componentName->setTo("OMX.ffmpeg.aac.decoder");
+        }
+    }
+}
+
+status_t FFMPEGSoftCodec::setVideoFormat(
+        const sp<AMessage> &msg, const char* mime, sp<IOMX> OMXhandle,
+        IOMX::node_id nodeID, bool isEncoder,
+        OMX_VIDEO_CODINGTYPE *compressionFormat) {
+    status_t err = OK;
+
+    if (isEncoder) {
+        ALOGE("Encoding not supported");
+        err = BAD_VALUE;
+    
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_WMV, mime)) {
+        err = setWMVFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setWMVFormat() failed (err = %d)", err);
+        } else {
+            *compressionFormat = OMX_VIDEO_CodingWMV;
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_RV, mime)) {
+        err = setRVFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setRVFormat() failed (err = %d)", err);
+        } else {
+            *compressionFormat = OMX_VIDEO_CodingRV;
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_VC1, mime)) {
+        *compressionFormat = (OMX_VIDEO_CODINGTYPE)OMX_VIDEO_CodingVC1;
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_FLV1, mime)) {
+        *compressionFormat = (OMX_VIDEO_CODINGTYPE)OMX_VIDEO_CodingFLV1;
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_DIVX, mime)) {
+        *compressionFormat = (OMX_VIDEO_CODINGTYPE)OMX_VIDEO_CodingDIVX;
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_HEVC, mime)) {
+        *compressionFormat = (OMX_VIDEO_CODINGTYPE)OMX_VIDEO_CodingHEVC;
+    } else if (!strcasecmp(MEDIA_MIMETYPE_VIDEO_FFMPEG, mime)) {
+        ALOGV("Setting the OMX_VIDEO_PARAM_FFMPEGTYPE params");
+        err = setFFmpegVideoFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setFFmpegVideoFormat() failed (err = %d)", err);
+        } else {
+            *compressionFormat = OMX_VIDEO_CodingAutoDetect;
+        }
+    } else {
+        err = BAD_TYPE;
+    }
+
+    return err;
+}
+
+status_t FFMPEGSoftCodec::getVideoPortFormat(OMX_U32 portIndex, int coding,
+        sp<AMessage> &notify, sp<IOMX> OMXHandle, IOMX::node_id nodeId) {
+
+    status_t err = BAD_TYPE;
+    switch (coding) {
+        case OMX_VIDEO_CodingWMV:
+        {
+            OMX_VIDEO_PARAM_WMVTYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, OMX_IndexParamVideoWmv, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            int32_t version;
+            if (params.eFormat == OMX_VIDEO_WMVFormat7) {
+                version = kTypeWMVVer_7;
+            } else if (params.eFormat == OMX_VIDEO_WMVFormat8) {
+                version = kTypeWMVVer_8;
+            } else {
+                version = kTypeWMVVer_9;
+            }
+            notify->setString("mime", MEDIA_MIMETYPE_VIDEO_WMV);
+            notify->setInt32("wmv-version", version);
+            break;
+        }
+        case OMX_VIDEO_CodingAutoDetect:
+        {
+            OMX_VIDEO_PARAM_FFMPEGTYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamVideoFFmpeg, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_VIDEO_FFMPEG);
+            notify->setInt32("codec-id", params.eCodecId);
+            break;
+        }
+        case OMX_VIDEO_CodingRV:
+        {
+            OMX_VIDEO_PARAM_RVTYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamVideoRv, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            int32_t version;
+            if (params.eFormat == OMX_VIDEO_RVFormatG2) {
+                version = kTypeRVVer_G2;
+            } else if (params.eFormat == OMX_VIDEO_RVFormat8) {
+                version = kTypeRVVer_8;
+            } else {
+                version = kTypeRVVer_9;
+            }
+            notify->setString("mime", MEDIA_MIMETYPE_VIDEO_RV);
+            break;
+        }
+    }
+    return err;
+}
+
+status_t FFMPEGSoftCodec::getAudioPortFormat(OMX_U32 portIndex, int coding,
+        sp<AMessage> &notify, sp<IOMX> OMXHandle, IOMX::node_id nodeId) {
+
+    status_t err = BAD_TYPE;
+    switch (coding) {
+        case OMX_AUDIO_CodingRA:
+        {
+            OMX_AUDIO_PARAM_RATYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, OMX_IndexParamAudioRa, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_RA);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSamplingRate);
+            break;
+        }
+        case OMX_AUDIO_CodingMP2:
+        {
+            OMX_AUDIO_PARAM_MP2TYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamAudioMp2, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_MPEG_LAYER_II);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSampleRate);
+            break;
+        }
+        case OMX_AUDIO_CodingWMA:
+        {
+            OMX_AUDIO_PARAM_WMATYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, OMX_IndexParamAudioWma, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_WMA);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSamplingRate);
+            break;
+        }
+        case OMX_AUDIO_CodingAPE:
+        {
+            OMX_AUDIO_PARAM_APETYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamAudioApe, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_APE);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSamplingRate);
+            notify->setInt32("bit-width", params.nBitsPerSample);
+            break;
+        }
+        case OMX_AUDIO_CodingFLAC:
+        {
+            OMX_AUDIO_PARAM_FLACTYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamAudioFlac, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_FLAC);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSampleRate);
+            notify->setInt32("bit-width", params.nCompressionLevel); // piggyback
+            break;
+        }
+
+        case OMX_AUDIO_CodingDTS:
+        {
+            OMX_AUDIO_PARAM_DTSTYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamAudioDts, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_DTS);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSamplingRate);
+            break;
+        }
+        case OMX_AUDIO_CodingAC3:
+        {
+            OMX_AUDIO_PARAM_ANDROID_AC3TYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAc3, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_AC3);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSampleRate);
+            break;
+        }
+
+        case OMX_AUDIO_CodingAutoDetect:
+        {
+            OMX_AUDIO_PARAM_FFMPEGTYPE params;
+            InitOMXParams(&params);
+            params.nPortIndex = portIndex;
+
+            err = OMXHandle->getParameter(
+                    nodeId, (OMX_INDEXTYPE)OMX_IndexParamAudioFFmpeg, &params, sizeof(params));
+            if (err != OK) {
+                return err;
+            }
+
+            notify->setString("mime", MEDIA_MIMETYPE_AUDIO_FFMPEG);
+            notify->setInt32("channel-count", params.nChannels);
+            notify->setInt32("sample-rate", params.nSampleRate);
+            break;
+        }
+    }
+    return err;
+}
+
+status_t FFMPEGSoftCodec::setAudioFormat(
+        const sp<AMessage> &msg, const char* mime, sp<IOMX> OMXhandle,
+        IOMX::node_id nodeID) {
+    ALOGV("setAudioFormat called");
+    status_t err = OK;
+
+    ALOGV("setAudioFormat: %s", msg->debugString(0).c_str());
+
+    if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_WMA, mime))  {
+        err = setWMAFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setWMAFormat() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_VORBIS, mime))  {
+        err = setVORBISFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setVORBISFormat() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_RA, mime))  {
+        err = setRAFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setRAFormat() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_FLAC, mime))  {
+        err = setFLACFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setFLACFormat() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_MPEG_LAYER_II, mime))  {
+        err = setMP2Format(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setMP2Format() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_AC3, mime)) {
+        err = setAC3Format(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setAC3Format() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_APE, mime))  {
+        err = setAPEFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setAPEFormat() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_DTS, mime))  {
+        err = setDTSFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setDTSFormat() failed (err = %d)", err);
+        }
+    } else if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_FFMPEG, mime))  {
+        err = setFFmpegAudioFormat(msg, OMXhandle, nodeID);
+        if (err != OK) {
+            ALOGE("setFFmpegAudioFormat() failed (err = %d)", err);
+        }
+    }
+
+    return err;
+}
+
+status_t FFMPEGSoftCodec::setSupportedRole(
+        const sp<IOMX> &omx, IOMX::node_id node,
+        bool isEncoder, const char *mime) {
+
+    ALOGV("setSupportedRole Called %s", mime);
+
+    struct MimeToRole {
+        const char *mime;
+        const char *decoderRole;
+        const char *encoderRole;
+    };
+
+    static const MimeToRole kFFMPEGMimeToRole[] = {
+        { MEDIA_MIMETYPE_AUDIO_AAC,
+          "audio_decoder.aac", NULL },
+        { MEDIA_MIMETYPE_AUDIO_MPEG,
+          "audio_decoder.mp3", NULL },
+        { MEDIA_MIMETYPE_AUDIO_VORBIS,
+          "audio_decoder.vorbis", NULL },
+        { MEDIA_MIMETYPE_AUDIO_WMA,
+          "audio_decoder.wma", NULL },
+        { MEDIA_MIMETYPE_AUDIO_RA,
+          "audio_decoder.ra" , NULL },
+        { MEDIA_MIMETYPE_AUDIO_FLAC,
+          "audio_decoder.flac", NULL },
+        { MEDIA_MIMETYPE_AUDIO_MPEG_LAYER_II,
+          "audio_decoder.mp2", NULL },
+        { MEDIA_MIMETYPE_AUDIO_AC3,
+          "audio_decoder.ac3", NULL },
+        { MEDIA_MIMETYPE_AUDIO_APE,
+          "audio_decoder.ape", NULL },
+        { MEDIA_MIMETYPE_AUDIO_DTS,
+          "audio_decoder.dts", NULL },
+        { MEDIA_MIMETYPE_VIDEO_MPEG2,
+          "video_decoder.mpeg2", NULL },
+        { MEDIA_MIMETYPE_VIDEO_DIVX,
+          "video_decoder.divx", NULL },
+        { MEDIA_MIMETYPE_VIDEO_DIVX4,
+          "video_decoder.divx", NULL },
+        { MEDIA_MIMETYPE_VIDEO_DIVX311,
+          "video_decoder.divx", NULL },
+        { MEDIA_MIMETYPE_VIDEO_WMV,
+          "video_decoder.wmv",  NULL },
+        { MEDIA_MIMETYPE_VIDEO_VC1,
+          "video_decoder.vc1", NULL },
+        { MEDIA_MIMETYPE_VIDEO_RV,
+          "video_decoder.rv", NULL },
+        { MEDIA_MIMETYPE_VIDEO_FLV1,
+          "video_decoder.flv1", NULL },
+        { MEDIA_MIMETYPE_VIDEO_HEVC,
+          "video_decoder.hevc", NULL },
+        { MEDIA_MIMETYPE_AUDIO_FFMPEG,
+          "audio_decoder.trial", NULL },
+        { MEDIA_MIMETYPE_VIDEO_FFMPEG,
+          "video_decoder.trial", NULL },
+        };
+    static const size_t kNumMimeToRole =
+                     sizeof(kFFMPEGMimeToRole) / sizeof(kFFMPEGMimeToRole[0]);
+
+    size_t i;
+    for (i = 0; i < kNumMimeToRole; ++i) {
+        if (!strcasecmp(mime, kFFMPEGMimeToRole[i].mime)) {
+            break;
+        }
+    }
+
+    if (i == kNumMimeToRole) {
+        return ERROR_UNSUPPORTED;
+    }
+
+    const char *role =
+        isEncoder ? kFFMPEGMimeToRole[i].encoderRole
+                  : kFFMPEGMimeToRole[i].decoderRole;
+
+    if (role != NULL) {
+        OMX_PARAM_COMPONENTROLETYPE roleParams;
+        InitOMXParams(&roleParams);
+
+        strncpy((char *)roleParams.cRole,
+                role, OMX_MAX_STRINGNAME_SIZE - 1);
+
+        roleParams.cRole[OMX_MAX_STRINGNAME_SIZE - 1] = '\0';
+
+        status_t err = omx->setParameter(
+                node, OMX_IndexParamStandardComponentRole,
+                &roleParams, sizeof(roleParams));
+
+        if (err != OK) {
+            ALOGW("Failed to set standard component role '%s'.", role);
+            return err;
+        }
+    }
+    return OK;
+}
+
+//video
+status_t FFMPEGSoftCodec::setWMVFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t version = -1;
+    OMX_VIDEO_PARAM_WMVTYPE paramWMV;
+
+    if (!msg->findInt32(getMsgKey(kKeyWMVVersion), &version)) {
+        ALOGE("WMV version not detected");
+    }
+
+    InitOMXParams(&paramWMV);
+    paramWMV.nPortIndex = kPortIndexInput;
+
+    status_t err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamVideoWmv, &paramWMV, sizeof(paramWMV));
+    if (err != OK) {
+        return err;
+    }
+
+    if (version == kTypeWMVVer_7) {
+        paramWMV.eFormat = OMX_VIDEO_WMVFormat7;
+    } else if (version == kTypeWMVVer_8) {
+        paramWMV.eFormat = OMX_VIDEO_WMVFormat8;
+    } else if (version == kTypeWMVVer_9) {
+        paramWMV.eFormat = OMX_VIDEO_WMVFormat9;
+    }
+
+    err = OMXhandle->setParameter(
+            nodeID, OMX_IndexParamVideoWmv, &paramWMV, sizeof(paramWMV));
+    return err;
+}
+
+status_t FFMPEGSoftCodec::setRVFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t version = kTypeRVVer_G2;
+    OMX_VIDEO_PARAM_RVTYPE paramRV;
+
+    if (!msg->findInt32(getMsgKey(kKeyRVVersion), &version)) {
+        ALOGE("RV version not detected");
+    }
+
+    InitOMXParams(&paramRV);
+    paramRV.nPortIndex = kPortIndexInput;
+
+    status_t err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamVideoRv, &paramRV, sizeof(paramRV));
+    if (err != OK)
+        return err;
+
+    if (version == kTypeRVVer_G2) {
+        paramRV.eFormat = OMX_VIDEO_RVFormatG2;
+    } else if (version == kTypeRVVer_8) {
+        paramRV.eFormat = OMX_VIDEO_RVFormat8;
+    } else if (version == kTypeRVVer_9) {
+        paramRV.eFormat = OMX_VIDEO_RVFormat9;
+    }
+
+    err = OMXhandle->setParameter(
+            nodeID, OMX_IndexParamVideoRv, &paramRV, sizeof(paramRV));
+    return err;
+}
+
+status_t FFMPEGSoftCodec::setFFmpegVideoFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t codec_id = 0;
+    int32_t width = 0;
+    int32_t height = 0;
+    OMX_VIDEO_PARAM_FFMPEGTYPE param;
+
+    ALOGD("setFFmpegVideoFormat");
+
+    if (msg->findInt32(getMsgKey(kKeyWidth), &width)) {
+        ALOGE("No video width specified");
+    }
+    if (msg->findInt32(getMsgKey(kKeyHeight), &height)) {
+        ALOGE("No video height specified");
+    }
+    if (!msg->findInt32(getMsgKey(kKeyCodecId), &codec_id)) {
+        ALOGE("No codec id sent for FFMPEG catch-all codec!");
+    }
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    status_t err = OMXhandle->getParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamVideoFFmpeg, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.eCodecId = codec_id;
+    param.nWidth   = width;
+    param.nHeight  = height;
+
+    err = OMXhandle->setParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamVideoFFmpeg, &param, sizeof(param));
+    return err;
+}
+
+//audio
+status_t FFMPEGSoftCodec::setRawAudioFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    int32_t bitsPerSample = 16;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+    if (!msg->findInt32(getMsgKey(kKeyBitsPerSample), &bitsPerSample)) {
+        ALOGD("No PCM format specified, using 16 bit");
+    }
+
+    OMX_PARAM_PORTDEFINITIONTYPE def;
+    InitOMXParams(&def);
+    def.nPortIndex = kPortIndexOutput;
+
+    status_t err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamPortDefinition, &def, sizeof(def));
+
+    if (err != OK) {
+        return err;
+    }
+
+    def.format.audio.eEncoding = OMX_AUDIO_CodingPCM;
+
+    err = OMXhandle->setParameter(
+            nodeID, OMX_IndexParamPortDefinition, &def, sizeof(def));
+
+    if (err != OK) {
+        return err;
+    }
+
+    OMX_AUDIO_PARAM_PCMMODETYPE pcmParams;
+    InitOMXParams(&pcmParams);
+    pcmParams.nPortIndex = kPortIndexOutput;
+
+    err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamAudioPcm, &pcmParams, sizeof(pcmParams));
+
+    if (err != OK) {
+        return err;
+    }
+
+    pcmParams.nChannels = numChannels;
+    pcmParams.eNumData = OMX_NumericalDataSigned;
+    pcmParams.bInterleaved = OMX_TRUE;
+    pcmParams.nBitPerSample = bitsPerSample;
+    pcmParams.nSamplingRate = sampleRate;
+    pcmParams.ePCMMode = OMX_AUDIO_PCMModeLinear;
+
+    if (getOMXChannelMapping(numChannels, pcmParams.eChannelMapping) != OK) {
+        return OMX_ErrorNone;
+    }
+
+    return OMXhandle->setParameter(
+            nodeID, OMX_IndexParamAudioPcm, &pcmParams, sizeof(pcmParams));
+}
+
+status_t FFMPEGSoftCodec::setWMAFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t version = 0;
+    int32_t numChannels = 0;
+    int32_t bitRate = 0;
+    int32_t sampleRate = 0;
+    int32_t blockAlign = 0;
+    int32_t bitsPerSample = 0;
+
+    OMX_AUDIO_PARAM_WMATYPE paramWMA;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+    CHECK(msg->findInt32(getMsgKey(kKeyBitRate), &bitRate));
+    if (!msg->findInt32(getMsgKey(kKeyBlockAlign), &blockAlign)) {
+        // we should be last on the codec list, but another sniffer may
+        // have handled it and there is no hardware codec.
+        if (!msg->findInt32(getMsgKey(kKeyWMABlockAlign), &blockAlign)) {
+            return ERROR_UNSUPPORTED;
+        }
+    }
+
+    // mm-parser may want a different bit depth
+    if (msg->findInt32(getMsgKey(kKeyWMABitspersample), &bitsPerSample)) {
+        msg->setInt32("bit-width", bitsPerSample);
+    }
+
+    ALOGV("Channels: %d, SampleRate: %d, BitRate: %d, blockAlign: %d",
+            numChannels, sampleRate, bitRate, blockAlign);
+
+    CHECK(msg->findInt32(getMsgKey(kKeyWMAVersion), &version));
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&paramWMA);
+    paramWMA.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamAudioWma, &paramWMA, sizeof(paramWMA));
+    if (err != OK)
+        return err;
+
+    paramWMA.nChannels = numChannels;
+    paramWMA.nSamplingRate = sampleRate;
+    paramWMA.nBitRate = bitRate;
+    paramWMA.nBlockAlign = blockAlign;
+
+    // http://msdn.microsoft.com/en-us/library/ff819498(v=vs.85).aspx
+    if (version == kTypeWMA) {
+        paramWMA.eFormat = OMX_AUDIO_WMAFormat7;
+    } else if (version == kTypeWMAPro) {
+        paramWMA.eFormat = OMX_AUDIO_WMAFormat8;
+    } else if (version == kTypeWMALossLess) {
+        paramWMA.eFormat = OMX_AUDIO_WMAFormat9;
+    }
+
+    return OMXhandle->setParameter(
+            nodeID, OMX_IndexParamAudioWma, &paramWMA, sizeof(paramWMA));
+}
+
+status_t FFMPEGSoftCodec::setVORBISFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    OMX_AUDIO_PARAM_VORBISTYPE param;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+
+    ALOGV("Channels: %d, SampleRate: %d",
+            numChannels, sampleRate);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamAudioVorbis, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.nChannels = numChannels;
+    param.nSampleRate = sampleRate;
+
+    return OMXhandle->setParameter(
+            nodeID, OMX_IndexParamAudioVorbis, &param, sizeof(param));
+}
+
+status_t FFMPEGSoftCodec::setRAFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t bitRate = 0;
+    int32_t sampleRate = 0;
+    int32_t blockAlign = 0;
+    OMX_AUDIO_PARAM_RATYPE paramRA;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+    msg->findInt32(getMsgKey(kKeyBitRate), &bitRate);
+    CHECK(msg->findInt32(getMsgKey(kKeyBlockAlign), &blockAlign));
+
+    ALOGV("Channels: %d, SampleRate: %d, BitRate: %d, blockAlign: %d",
+            numChannels, sampleRate, bitRate, blockAlign);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&paramRA);
+    paramRA.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamAudioRa, &paramRA, sizeof(paramRA));
+    if (err != OK)
+        return err;
+
+    paramRA.eFormat = OMX_AUDIO_RAFormatUnused; // FIXME, cook only???
+    paramRA.nChannels = numChannels;
+    paramRA.nSamplingRate = sampleRate;
+    // FIXME, HACK!!!, I use the nNumRegions parameter pass blockAlign!!!
+    // the cook audio codec need blockAlign!
+    paramRA.nNumRegions = blockAlign;
+
+    return OMXhandle->setParameter(
+            nodeID, OMX_IndexParamAudioRa, &paramRA, sizeof(paramRA));
+}
+
+status_t FFMPEGSoftCodec::setFLACFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    int32_t bitsPerSample = 16;
+    OMX_AUDIO_PARAM_FLACTYPE param;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+    CHECK(msg->findInt32(getMsgKey(kKeyBitsPerSample), &bitsPerSample));
+
+    ALOGV("Channels: %d, SampleRate: %d BitsPerSample: %d",
+            numChannels, sampleRate, bitsPerSample);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, OMX_IndexParamAudioFlac, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.nChannels = numChannels;
+    param.nSampleRate = sampleRate;
+    param.nCompressionLevel = bitsPerSample; // piggyback hax!
+
+    return OMXhandle->setParameter(
+            nodeID, OMX_IndexParamAudioFlac, &param, sizeof(param));
+}
+
+status_t FFMPEGSoftCodec::setMP2Format(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    OMX_AUDIO_PARAM_MP2TYPE param;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+
+    ALOGV("Channels: %d, SampleRate: %d",
+            numChannels, sampleRate);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioMp2, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.nChannels = numChannels;
+    param.nSampleRate = sampleRate;
+
+    return OMXhandle->setParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioMp2, &param, sizeof(param));
+}
+
+status_t FFMPEGSoftCodec::setAC3Format(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    OMX_AUDIO_PARAM_ANDROID_AC3TYPE param;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+
+    ALOGV("Channels: %d, SampleRate: %d",
+            numChannels, sampleRate);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAc3, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.nChannels = numChannels;
+    param.nSampleRate = sampleRate;
+
+    return OMXhandle->setParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAc3, &param, sizeof(param));
+}
+
+status_t FFMPEGSoftCodec::setAPEFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    int32_t bitsPerSample = 0;
+    OMX_AUDIO_PARAM_APETYPE param;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+    CHECK(msg->findInt32(getMsgKey(kKeyBitsPerSample), &bitsPerSample));
+
+    ALOGV("Channels:%d, SampleRate:%d, bitsPerSample:%d",
+            numChannels, sampleRate, bitsPerSample);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioApe, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.nChannels = numChannels;
+    param.nSamplingRate = sampleRate;
+    param.nBitsPerSample = bitsPerSample;
+
+    return OMXhandle->setParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioApe, &param, sizeof(param));
+}
+
+status_t FFMPEGSoftCodec::setDTSFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t numChannels = 0;
+    int32_t sampleRate = 0;
+    OMX_AUDIO_PARAM_DTSTYPE param;
+
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate));
+
+    ALOGV("Channels: %d, SampleRate: %d",
+            numChannels, sampleRate);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioDts, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.nChannels = numChannels;
+    param.nSamplingRate = sampleRate;
+
+    return OMXhandle->setParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioDts, &param, sizeof(param));
+}
+
+status_t FFMPEGSoftCodec::setFFmpegAudioFormat(
+        const sp<AMessage> &msg, sp<IOMX> OMXhandle, IOMX::node_id nodeID)
+{
+    int32_t codec_id = 0;
+    int32_t numChannels = 0;
+    int32_t bitRate = 0;
+    int32_t bitsPerSample = 16;
+    int32_t sampleRate = 0;
+    int32_t blockAlign = 0;
+    int32_t sampleFormat = 0;
+    int32_t codedSampleBits = 0;
+    OMX_AUDIO_PARAM_FFMPEGTYPE param;
+
+    ALOGD("setFFmpegAudioFormat");
+
+    CHECK(msg->findInt32(getMsgKey(kKeyCodecId), &codec_id));
+    CHECK(msg->findInt32(getMsgKey(kKeyChannelCount), &numChannels));
+    CHECK(msg->findInt32(getMsgKey(kKeySampleFormat), &sampleFormat));
+    msg->findInt32(getMsgKey(kKeyBitRate), &bitRate);
+    msg->findInt32(getMsgKey(kKeyBitsPerSample), &bitsPerSample);
+    msg->findInt32(getMsgKey(kKeySampleRate), &sampleRate);
+    msg->findInt32(getMsgKey(kKeyBlockAlign), &blockAlign);
+    msg->findInt32(getMsgKey(kKeyBitsPerSample), &bitsPerSample);
+    msg->findInt32(getMsgKey(kKeyCodedSampleBits), &codedSampleBits);
+
+    status_t err = setRawAudioFormat(msg, OMXhandle, nodeID);
+    if (err != OK)
+        return err;
+
+    InitOMXParams(&param);
+    param.nPortIndex = kPortIndexInput;
+
+    err = OMXhandle->getParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioFFmpeg, &param, sizeof(param));
+    if (err != OK)
+        return err;
+
+    param.eCodecId       = codec_id;
+    param.nChannels      = numChannels;
+    param.nBitRate       = bitRate;
+    param.nBitsPerSample = codedSampleBits;
+    param.nSampleRate    = sampleRate;
+    param.nBlockAlign    = blockAlign;
+    param.eSampleFormat  = sampleFormat;
+
+    return OMXhandle->setParameter(
+            nodeID, (OMX_INDEXTYPE)OMX_IndexParamAudioFFmpeg, &param, sizeof(param));
+}
+
+}

--- a/media/libstagefright/FLACExtractor.cpp
+++ b/media/libstagefright/FLACExtractor.cpp
@@ -845,12 +845,14 @@ bool SniffFLAC(
 {
     // first 4 is the signature word
     // second 4 is the sizeof STREAMINFO
+    // 1st bit of 2nd 4 bytes represent whether last block of metadata or not
     // 042 is the mandatory STREAMINFO
     // no need to read rest of the header, as a premature EOF will be caught later
     uint8_t header[4+4];
     if (source->readAt(0, header, sizeof(header)) != sizeof(header)
-            || memcmp("fLaC\0\0\0\042", header, 4+4))
-    {
+            || memcmp("fLaC", header, 4)
+            || !(header[4] == 0x80 || header[4] == 0x00)
+            || memcmp("\0\0\042", header + 5, 3))    {
         return false;
     }
 

--- a/media/libstagefright/FLACExtractor.cpp
+++ b/media/libstagefright/FLACExtractor.cpp
@@ -32,6 +32,13 @@
 #include <media/stagefright/MediaSource.h>
 #include <media/stagefright/MediaBuffer.h>
 
+#ifdef ENABLE_AV_ENHANCEMENTS
+#include "QCMediaDefs.h"
+#include "QCMetaData.h"
+#endif
+
+#include <system/audio.h>
+
 namespace android {
 
 class FLACParser;
@@ -72,6 +79,8 @@ private:
 
 class FLACParser : public RefBase {
 
+friend class FLACSource;
+
 public:
     FLACParser(
         const sp<DataSource> &dataSource,
@@ -103,6 +112,8 @@ public:
     // media buffers
     void allocateBuffers();
     void releaseBuffers();
+    void copyBuffer(short *dst, const int *const *src, unsigned nSamples);
+
     MediaBuffer *readBuffer() {
         return readBuffer(false, 0LL);
     }
@@ -113,6 +124,7 @@ public:
 protected:
     virtual ~FLACParser();
 
+
 private:
     sp<DataSource> mDataSource;
     sp<MetaData> mFileMetadata;
@@ -122,7 +134,6 @@ private:
     // media buffers
     size_t mMaxBufferSize;
     MediaBufferGroup *mGroup;
-    void (*mCopy)(short *dst, const int *const *src, unsigned nSamples, unsigned nChannels);
 
     // handle to underlying libFLAC parser
     FLAC__StreamDecoder *mDecoder;
@@ -377,107 +388,39 @@ void FLACParser::errorCallback(FLAC__StreamDecoderErrorStatus status)
     mErrorStatus = status;
 }
 
-// Copy samples from FLAC native 32-bit non-interleaved to 16-bit interleaved.
-// These are candidates for optimization if needed.
-
-static void copyMono8(
-        short *dst,
-        const int *const *src,
-        unsigned nSamples,
-        unsigned /* nChannels */) {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        *dst++ = src[0][i] << 8;
-    }
-}
-
-static void copyStereo8(
-        short *dst,
-        const int *const *src,
-        unsigned nSamples,
-        unsigned /* nChannels */) {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        *dst++ = src[0][i] << 8;
-        *dst++ = src[1][i] << 8;
-    }
-}
-
-static void copyMultiCh8(short *dst, const int *const *src, unsigned nSamples, unsigned nChannels)
+void FLACParser::copyBuffer(short *dst, const int *const *src, unsigned nSamples)
 {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        for (unsigned c = 0; c < nChannels; ++c) {
-            *dst++ = src[c][i] << 8;
+    unsigned int nChannels = getChannels();
+    unsigned int nBits = getBitsPerSample();
+    switch (nBits) {
+        case 8:
+            for (unsigned i = 0; i < nSamples; ++i) {
+                for (unsigned c = 0; c < nChannels; ++c) {
+                    *dst++ = src[c][i] << 8;
+                }
+            }
+            break;
+        case 16:
+            for (unsigned i = 0; i < nSamples; ++i) {
+                for (unsigned c = 0; c < nChannels; ++c) {
+                    *dst++ = src[c][i];
+                }
+            }
+            break;
+        case 24:
+        case 32:
+        {
+            int32_t *out = (int32_t *)dst;
+            for (unsigned i = 0; i < nSamples; ++i) {
+                for (unsigned c = 0; c < nChannels; ++c) {
+                    *out++ = src[c][i] << 8;
+                }
+            }
+            break;
         }
+        default:
+            TRESPASS();
     }
-}
-
-static void copyMono16(
-        short *dst,
-        const int *const *src,
-        unsigned nSamples,
-        unsigned /* nChannels */) {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        *dst++ = src[0][i];
-    }
-}
-
-static void copyStereo16(
-        short *dst,
-        const int *const *src,
-        unsigned nSamples,
-        unsigned /* nChannels */) {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        *dst++ = src[0][i];
-        *dst++ = src[1][i];
-    }
-}
-
-static void copyMultiCh16(short *dst, const int *const *src, unsigned nSamples, unsigned nChannels)
-{
-    for (unsigned i = 0; i < nSamples; ++i) {
-        for (unsigned c = 0; c < nChannels; ++c) {
-            *dst++ = src[c][i];
-        }
-    }
-}
-
-// 24-bit versions should do dithering or noise-shaping, here or in AudioFlinger
-
-static void copyMono24(
-        short *dst,
-        const int *const *src,
-        unsigned nSamples,
-        unsigned /* nChannels */) {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        *dst++ = src[0][i] >> 8;
-    }
-}
-
-static void copyStereo24(
-        short *dst,
-        const int *const *src,
-        unsigned nSamples,
-        unsigned /* nChannels */) {
-    for (unsigned i = 0; i < nSamples; ++i) {
-        *dst++ = src[0][i] >> 8;
-        *dst++ = src[1][i] >> 8;
-    }
-}
-
-static void copyMultiCh24(short *dst, const int *const *src, unsigned nSamples, unsigned nChannels)
-{
-    for (unsigned i = 0; i < nSamples; ++i) {
-        for (unsigned c = 0; c < nChannels; ++c) {
-            *dst++ = src[c][i] >> 8;
-        }
-    }
-}
-
-static void copyTrespass(
-        short * /* dst */,
-        const int *const * /* src */,
-        unsigned /* nSamples */,
-        unsigned /* nChannels */) {
-    TRESPASS();
 }
 
 // FLACParser
@@ -492,7 +435,6 @@ FLACParser::FLACParser(
       mInitCheck(false),
       mMaxBufferSize(0),
       mGroup(NULL),
-      mCopy(copyTrespass),
       mDecoder(NULL),
       mCurrentPos(0LL),
       mEOF(false),
@@ -571,6 +513,8 @@ status_t FLACParser::init()
         }
         // check sample rate
         switch (getSampleRate()) {
+        case   100:
+        case  1000:
         case  8000:
         case 11025:
         case 12000:
@@ -578,37 +522,17 @@ status_t FLACParser::init()
         case 22050:
         case 24000:
         case 32000:
+        case 42000:
         case 44100:
+        case 46000:
         case 48000:
         case 88200:
         case 96000:
+        case 192000:
             break;
         default:
             ALOGE("unsupported sample rate %u", getSampleRate());
             return NO_INIT;
-        }
-        // configure the appropriate copy function, defaulting to trespass
-        static const struct {
-            unsigned mChannels;
-            unsigned mBitsPerSample;
-            void (*mCopy)(short *dst, const int *const *src, unsigned nSamples, unsigned nChannels);
-        } table[] = {
-            { 1,  8, copyMono8    },
-            { 2,  8, copyStereo8  },
-            { 8,  8, copyMultiCh8  },
-            { 1, 16, copyMono16   },
-            { 2, 16, copyStereo16 },
-            { 8, 16, copyMultiCh16 },
-            { 1, 24, copyMono24   },
-            { 2, 24, copyStereo24 },
-            { 8, 24, copyMultiCh24 },
-        };
-        for (unsigned i = 0; i < sizeof(table)/sizeof(table[0]); ++i) {
-            if (table[i].mChannels >= getChannels() &&
-                    table[i].mBitsPerSample == getBitsPerSample()) {
-                mCopy = table[i].mCopy;
-                break;
-            }
         }
         // populate track metadata
         if (mTrackMetadata != 0) {
@@ -618,6 +542,7 @@ status_t FLACParser::init()
             // sample rate is non-zero, so division by zero not possible
             mTrackMetadata->setInt64(kKeyDuration,
                     (getTotalSamples() * 1000000LL) / getSampleRate());
+            mTrackMetadata->setInt32(kKeyBitsPerSample, getBitsPerSample());
         }
     } else {
         ALOGE("missing STREAMINFO");
@@ -633,7 +558,9 @@ void FLACParser::allocateBuffers()
 {
     CHECK(mGroup == NULL);
     mGroup = new MediaBufferGroup;
-    mMaxBufferSize = getMaxBlockSize() * getChannels() * sizeof(short);
+    // allocate enough to hold 24-bits (packed in 32 bits)
+    unsigned int bytesPerSample = getBitsPerSample() > 16 ? 4 : 2;
+    mMaxBufferSize = getMaxBlockSize() * getChannels() * bytesPerSample;
     mGroup->add_buffer(new MediaBuffer(mMaxBufferSize));
 }
 
@@ -686,12 +613,12 @@ MediaBuffer *FLACParser::readBuffer(bool doSeek, FLAC__uint64 sample)
     if (err != OK) {
         return NULL;
     }
-    size_t bufferSize = blocksize * getChannels() * sizeof(short);
+    size_t bufferSize = blocksize * getChannels() * (getBitsPerSample() > 16 ? 4 : 2);
     CHECK(bufferSize <= mMaxBufferSize);
     short *data = (short *) buffer->data();
     buffer->set_range(0, bufferSize);
     // copy PCM from FLAC write buffer to our media buffer, with interleaving
-    (*mCopy)(data, mWriteBuffer, blocksize, getChannels());
+    copyBuffer(data, mWriteBuffer, blocksize);
     // fill in buffer metadata
     CHECK(mWriteHeader.number_type == FLAC__FRAME_NUMBER_TYPE_SAMPLE_NUMBER);
     FLAC__uint64 sampleNumber = mWriteHeader.number.sample_number;
@@ -726,9 +653,10 @@ FLACSource::~FLACSource()
 
 status_t FLACSource::start(MetaData * /* params */)
 {
+    CHECK(!mStarted);
+
     ALOGV("FLACSource::start");
 
-    CHECK(!mStarted);
     mParser->allocateBuffers();
     mStarted = true;
 

--- a/media/libstagefright/FileSource.cpp
+++ b/media/libstagefright/FileSource.cpp
@@ -30,6 +30,7 @@ namespace android {
 
 FileSource::FileSource(const char *filename)
     : mFd(-1),
+      mUri(filename),
       mOffset(0),
       mLength(-1),
       mDecryptHandle(NULL),
@@ -58,6 +59,7 @@ FileSource::FileSource(int fd, int64_t offset, int64_t length)
       mDrmBuf(NULL){
     CHECK(offset >= 0);
     CHECK(length >= 0);
+    fetchUriFromFd(fd);
 }
 
 FileSource::~FileSource() {
@@ -186,6 +188,20 @@ ssize_t FileSource::readAtDRM(off64_t offset, void *data, size_t size) {
     } else {
         /* Too big chunk to cache. Call DRM directly */
         return mDrmManagerClient->pread(mDecryptHandle, data, size, offset + mOffset);
+    }
+}
+
+void FileSource::fetchUriFromFd(int fd) {
+    ssize_t len = 0;
+    char path[PATH_MAX] = {0};
+    char link[PATH_MAX] = {0};
+
+    mUri.clear();
+
+    snprintf(path, PATH_MAX, "/proc/%d/fd/%d", getpid(), fd);
+    if ((len = readlink(path, link, sizeof(link)-1)) != -1) {
+        link[len] = '\0';
+        mUri.setTo(link);
     }
 }
 }  // namespace android

--- a/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/MPEG4Extractor.cpp
@@ -345,6 +345,9 @@ static const char *FourCC2MIME(uint32_t fourcc) {
         case FOURCC('m', 'p', '4', 'a'):
             return MEDIA_MIMETYPE_AUDIO_AAC;
 
+        case FOURCC('.', 'm', 'p', '3'):
+            return MEDIA_MIMETYPE_AUDIO_MPEG;
+
         case FOURCC('s', 'a', 'm', 'r'):
             return MEDIA_MIMETYPE_AUDIO_AMR_NB;
 
@@ -882,7 +885,7 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
             && chunk_type != FOURCC('c', 'o', 'v', 'r')
             && mPath.size() == 5 && underMetaDataPath(mPath)) {
         off64_t stop_offset = *offset + chunk_size;
-        *offset = data_offset;
+        *offset = stop_offset;
         while (*offset < stop_offset) {
             status_t err = parseChunk(offset, depth + 1);
             if (err != OK) {
@@ -1413,7 +1416,14 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
             mLastTrack->meta->setInt32(kKeySampleRate, sample_rate);
 
             off64_t stop_offset = *offset + chunk_size;
-            *offset = data_offset + sizeof(buffer);
+            if (!strcasecmp(MEDIA_MIMETYPE_AUDIO_MPEG, FourCC2MIME(chunk_type)) ||
+                !strcasecmp(MEDIA_MIMETYPE_AUDIO_AMR_WB, FourCC2MIME(chunk_type))) {
+                // ESD is not required in mp3
+                // amr wb with damr atom corrupted can cause the clip to not play
+               *offset = stop_offset;
+            } else {
+               *offset = data_offset + sizeof(buffer);
+            }
             while (*offset < stop_offset) {
                 status_t err = parseChunk(offset, depth + 1);
                 if (err != OK) {
@@ -3131,12 +3141,12 @@ status_t MPEG4Extractor::updateAudioTrackInfoFromESDS_MPEG4Audio(
         return OK;
     }
 
-    if (objectTypeIndication  == 0x6b) {
-        // The media subtype is MP3 audio
-        // Our software MP3 audio decoder may not be able to handle
-        // packetized MP3 audio; for now, lets just return ERROR_UNSUPPORTED
-        ALOGE("MP3 track in MP4/3GPP file is not supported");
-        return ERROR_UNSUPPORTED;
+    if (objectTypeIndication  == 0x6b
+         || objectTypeIndication  == 0x69) {
+         // This is mpeg1/2 audio content, set mimetype to mpeg
+         mLastTrack->meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_AUDIO_MPEG);
+         ALOGD("objectTypeIndication:0x%x, set mimetype to mpeg ",objectTypeIndication);
+         return OK;
     }
 
     const uint8_t *csd;
@@ -4769,7 +4779,9 @@ static bool LegacySniffMPEG4(
         return false;
     }
 
-    if (!memcmp(header, "ftyp3gp", 7) || !memcmp(header, "ftypmp42", 8)
+    if (!memcmp(header, "ftyp3g2a", 8) || !memcmp(header, "ftyp3g2b", 8)
+        || !memcmp(header, "ftyp3g2c", 8)
+        || !memcmp(header, "ftyp3gp", 7) || !memcmp(header, "ftypmp42", 8)
         || !memcmp(header, "ftyp3gr6", 8) || !memcmp(header, "ftyp3gs6", 8)
         || !memcmp(header, "ftyp3ge6", 8) || !memcmp(header, "ftyp3gg6", 8)
         || !memcmp(header, "ftypisom", 8) || !memcmp(header, "ftypM4V ", 8)

--- a/media/libstagefright/MediaCodec.cpp
+++ b/media/libstagefright/MediaCodec.cpp
@@ -1177,7 +1177,8 @@ void MediaCodec::onMessageReceived(const sp<AMessage> &msg) {
 
                     CHECK(msg->findString("componentName", &mComponentName));
 
-                    if (mComponentName.startsWith("OMX.google.")) {
+                    if (mComponentName.startsWith("OMX.google.") ||
+                            mComponentName.startsWith("OMX.ffmpeg.")) {
                         mFlags |= kFlagUsesSoftwareRenderer;
                     } else {
                         mFlags &= ~kFlagUsesSoftwareRenderer;

--- a/media/libstagefright/MediaDefs.cpp
+++ b/media/libstagefright/MediaDefs.cpp
@@ -86,4 +86,32 @@ const char *MEDIA_MIMETYPE_TEXT_VTT = "text/vtt";
 const char *MEDIA_MIMETYPE_TEXT_CEA_608 = "text/cea-608";
 const char *MEDIA_MIMETYPE_DATA_TIMED_ID3 = "application/x-id3v4";
 
+const char *MEDIA_MIMETYPE_VIDEO_FLV1 = "video/x-flv";
+const char *MEDIA_MIMETYPE_VIDEO_MJPEG = "video/x-jpeg";
+const char *MEDIA_MIMETYPE_VIDEO_RV = "video/vnd.rn-realvideo";
+const char *MEDIA_MIMETYPE_VIDEO_VC1 = "video/vc1";
+const char *MEDIA_MIMETYPE_VIDEO_FFMPEG = "video/ffmpeg";
+
+const char *MEDIA_MIMETYPE_AUDIO_PCM = "audio/x-pcm";
+const char *MEDIA_MIMETYPE_AUDIO_RA = "audio/vnd.rn-realaudio";
+const char *MEDIA_MIMETYPE_AUDIO_FFMPEG = "audio/ffmpeg";
+
+const char *MEDIA_MIMETYPE_CONTAINER_APE = "audio/x-ape";
+const char *MEDIA_MIMETYPE_CONTAINER_DIVX = "video/divx";
+const char *MEDIA_MIMETYPE_CONTAINER_DTS = "audio/vnd.dts";
+const char *MEDIA_MIMETYPE_CONTAINER_FLAC = "audio/flac";
+const char *MEDIA_MIMETYPE_CONTAINER_FLV = "video/x-flv";
+const char *MEDIA_MIMETYPE_CONTAINER_MOV = "video/quicktime";
+const char *MEDIA_MIMETYPE_CONTAINER_MP2 = "audio/mpeg2";
+const char *MEDIA_MIMETYPE_CONTAINER_MPG = "video/mpeg";
+const char *MEDIA_MIMETYPE_CONTAINER_RA = "audio/vnd.rn-realaudio";
+const char *MEDIA_MIMETYPE_CONTAINER_RM = "video/vnd.rn-realvideo";
+const char *MEDIA_MIMETYPE_CONTAINER_TS = "video/mp2t";
+const char *MEDIA_MIMETYPE_CONTAINER_WEBM = "video/webm";
+const char *MEDIA_MIMETYPE_CONTAINER_WMA = "audio/x-ms-wma";
+const char *MEDIA_MIMETYPE_CONTAINER_WMV = "video/x-ms-wmv";
+const char *MEDIA_MIMETYPE_CONTAINER_VC1 = "video/vc1";
+const char *MEDIA_MIMETYPE_CONTAINER_HEVC = "video/hevc";
+const char *MEDIA_MIMETYPE_CONTAINER_FFMPEG = "video/ffmpeg";
+
 }  // namespace android

--- a/media/libstagefright/MediaExtractor.cpp
+++ b/media/libstagefright/MediaExtractor.cpp
@@ -44,6 +44,8 @@
 
 namespace android {
 
+MediaExtractor::Plugin MediaExtractor::sPlugin;
+
 sp<MetaData> MediaExtractor::getMetaData() {
     return new MetaData;
 }
@@ -58,9 +60,15 @@ sp<MediaExtractor> MediaExtractor::Create(
         const uint32_t flags) {
     sp<AMessage> meta;
 
+    bool secondPass = false;
+
     String8 tmp;
-    if (mime == NULL) {
+retry:
+    if (secondPass || mime == NULL) {
         float confidence;
+        if (secondPass) {
+            confidence = 3.14f;
+        }
         if (!source->sniff(&tmp, &confidence, &meta)) {
             ALOGV("FAILED to autodetect media content.");
 
@@ -95,7 +103,12 @@ sp<MediaExtractor> MediaExtractor::Create(
     }
 
     sp<MediaExtractor> ret = NULL;
+    AString extractorName;
     if ((ret = AVFactory::get()->createExtendedExtractor(source, mime, meta, flags)) != NULL) {
+    } else if (meta.get() && meta->findString("extended-extractor-use", &extractorName)
+            && sPlugin.create) {
+        ALOGI("Use extended extractor for the special mime(%s) or codec", mime);
+        ret = sPlugin.create(source, mime, meta);
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_CONTAINER_MPEG4)
             || !strcasecmp(mime, "audio/mp4")) {
         ret = new MPEG4Extractor(source);
@@ -123,6 +136,8 @@ sp<MediaExtractor> MediaExtractor::Create(
         ret = new MPEG2PSExtractor(source);
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_MIDI)) {
         ret = new MidiExtractor(source);
+    } else if (!isDrm && sPlugin.create) {
+        ret = sPlugin.create(source, mime, meta);
     }
 
     ret = AVFactory::get()->updateExtractor(ret, source, mime, meta, flags);
@@ -132,6 +147,15 @@ sp<MediaExtractor> MediaExtractor::Create(
        } else {
            ret->setDrmFlag(false);
        }
+    }
+
+    if (ret != NULL) {
+
+        if (!secondPass && ( ret->countTracks() == 0 ||
+                    (!strncasecmp("video/", mime, 6) && ret->countTracks() < 2) ) ) {
+            secondPass = true;
+            goto retry;
+        }
     }
 
     return ret;

--- a/media/libstagefright/OMXClient.cpp
+++ b/media/libstagefright/OMXClient.cpp
@@ -181,6 +181,7 @@ bool MuxOMX::isLocalNode_l(node_id node) const {
 }
 
 // static
+
 bool MuxOMX::CanLiveLocally(const char *name) {
 #ifdef __LP64__
     (void)name; // disable unused parameter warning

--- a/media/libstagefright/StagefrightMediaScanner.cpp
+++ b/media/libstagefright/StagefrightMediaScanner.cpp
@@ -42,7 +42,11 @@ static bool FileHasAcceptableExtension(const char *extension) {
         ".mpeg", ".ogg", ".mid", ".smf", ".imy", ".wma", ".aac",
         ".wav", ".amr", ".midi", ".xmf", ".rtttl", ".rtx", ".ota",
         ".mkv", ".mka", ".webm", ".ts", ".fl", ".flac", ".mxmf",
-        ".avi", ".mpeg", ".mpg", ".awb", ".mpga"
+        ".adts", ".dm", ".m2ts", ".mp3d", ".wmv", ".asf", ".flv",
+        ".mov", ".ra", ".rm", ".rmvb", ".ac3", ".ape", ".dts",
+        ".mp1", ".mp2", ".f4v", "hlv", "nrg", "m2v", ".swf",
+        ".avi", ".mpg", ".mpeg", ".awb", ".vc1", ".vob", ".divx",
+        ".mpga", ".mov", ".qcp", ".ec3"
     };
     static const size_t kNumValidExtensions =
         sizeof(kValidExtensions) / sizeof(kValidExtensions[0]);

--- a/media/libstagefright/StagefrightMetadataRetriever.cpp
+++ b/media/libstagefright/StagefrightMetadataRetriever.cpp
@@ -458,6 +458,10 @@ VideoFrame *StagefrightMetadataRetriever::getFrameAtTime(
     for (i = 0; i < n; ++i) {
         sp<MetaData> meta = mExtractor->getTrackMetaData(i);
 
+        if (meta == NULL) {
+            continue;
+        }
+
         const char *mime;
         CHECK(meta->findCString(kKeyMIMEType, &mime));
 
@@ -628,6 +632,10 @@ void StagefrightMetadataRetriever::parseMetaData() {
 
     size_t numTracks = mExtractor->countTracks();
 
+    if (numTracks == 0) {      //If no tracks available, corrupt or not valid stream
+        return;
+    }
+
     char tmp[32];
     sprintf(tmp, "%zu", numTracks);
 
@@ -651,6 +659,9 @@ void StagefrightMetadataRetriever::parseMetaData() {
     String8 timedTextLang;
     for (size_t i = 0; i < numTracks; ++i) {
         sp<MetaData> trackMeta = mExtractor->getTrackMetaData(i);
+        if (trackMeta == NULL) {
+            continue;
+        }
 
         int64_t durationUs;
         if (trackMeta->findInt64(kKeyDuration, &durationUs)) {

--- a/media/libstagefright/Utils.cpp
+++ b/media/libstagefright/Utils.cpp
@@ -893,7 +893,7 @@ bool canOffloadStream(const sp<MetaData>& meta, bool hasVideo,
     info.sample_rate = srate;
 
     int32_t cmask = 0;
-    if (!meta->findInt32(kKeyChannelMask, &cmask)) {
+    if (!meta->findInt32(kKeyChannelMask, &cmask) || 0 == cmask) {
         ALOGV("track of type '%s' does not publish channel mask", mime);
 
         // Try a channel count instead

--- a/media/libstagefright/Utils.cpp
+++ b/media/libstagefright/Utils.cpp
@@ -329,7 +329,7 @@ status_t convertMetaDataToMessage(
     } else if (meta->findData(kKeyHVCC, &type, &data, &size)) {
         const uint8_t *ptr = (const uint8_t *)data;
 
-        if (size < 23 || ptr[0] != 1) {  // configurationVersion == 1
+        if (size < 23 || ptr[0] > 1) {  // configurationVersion == 1
             ALOGE("b/23680780");
             return BAD_VALUE;
         }

--- a/media/libstagefright/WAVExtractor.cpp
+++ b/media/libstagefright/WAVExtractor.cpp
@@ -29,6 +29,7 @@
 #include <media/stagefright/MetaData.h>
 #include <utils/String8.h>
 #include <cutils/bitops.h>
+#include <system/audio.h>
 
 #define CHANNEL_MASK_USE_CHANNEL_ORDER 0
 
@@ -284,6 +285,7 @@ status_t WAVExtractor::init() {
                     case WAVE_FORMAT_PCM:
                         mTrackMeta->setCString(
                                 kKeyMIMEType, MEDIA_MIMETYPE_AUDIO_RAW);
+                        mTrackMeta->setInt32(kKeyBitsPerSample, mBitsPerSample);
                         break;
                     case WAVE_FORMAT_ALAW:
                         mTrackMeta->setCString(
@@ -359,15 +361,16 @@ WAVSource::~WAVSource() {
 }
 
 status_t WAVSource::start(MetaData * /* params */) {
-    ALOGV("WAVSource::start");
 
-    CHECK(!mStarted);
+    if (mStarted) {
+        return OK;
+    }
 
     mGroup = new MediaBufferGroup;
     mGroup->add_buffer(new MediaBuffer(kMaxFrameSize));
 
-    if (mBitsPerSample == 8) {
-        // As a temporary buffer for 8->16 bit conversion.
+    if (mBitsPerSample == 8 || mBitsPerSample == 24) {
+        // As a temporary buffer for 8->16/24->32 bit conversion.
         mGroup->add_buffer(new MediaBuffer(kMaxFrameSize));
     }
 
@@ -427,9 +430,15 @@ status_t WAVSource::read(
     }
 
     // make sure that maxBytesToRead is multiple of 3, in 24-bit case
-    size_t maxBytesToRead =
-        mBitsPerSample == 8 ? kMaxFrameSize / 2 : 
-        (mBitsPerSample == 24 ? 3*(kMaxFrameSize/3): kMaxFrameSize);
+    size_t maxBytesToRead;
+    if(8 == mBitsPerSample)
+        maxBytesToRead = kMaxFrameSize / 2;
+    else if (24 == mBitsPerSample) {
+        maxBytesToRead = 3*(kMaxFrameSize/4);
+    } else
+        maxBytesToRead = kMaxFrameSize;
+    ALOGV("%s mBitsPerSample %d, kMaxFrameSize %d, ",
+          __func__, mBitsPerSample, kMaxFrameSize);
 
     size_t maxBytesAvailable =
         (mCurrentPos - mOffset >= (off64_t)mSize)
@@ -488,23 +497,24 @@ status_t WAVSource::read(
             buffer->release();
             buffer = tmp;
         } else if (mBitsPerSample == 24) {
-            // Convert 24-bit signed samples to 16-bit signed.
-
-            const uint8_t *src =
-                (const uint8_t *)buffer->data() + buffer->range_offset();
-            int16_t *dst = (int16_t *)src;
-
-            size_t numSamples = buffer->range_length() / 3;
-            for (size_t i = 0; i < numSamples; ++i) {
-                int32_t x = (int32_t)(src[0] | src[1] << 8 | src[2] << 16);
-                x = (x << 8) >> 8;  // sign extension
-
-                x = x >> 8;
-                *dst++ = (int16_t)x;
-                src += 3;
+            // Padding done here to convert to 32-bit samples
+            MediaBuffer *tmp;
+            CHECK_EQ(mGroup->acquire_buffer(&tmp), (status_t)OK);
+            ssize_t numBytes = buffer->range_length() / 3;
+            tmp->set_range(0, 4 * numBytes);
+            int8_t *dst = (int8_t *)tmp->data();
+            const uint8_t *src = (const uint8_t *)buffer->data();
+            ALOGV("numBytes = %d", numBytes);
+            while(numBytes-- > 0) {
+               *dst++ = 0x0;
+               *dst++ = src[0];
+               *dst++ = src[1];
+               *dst++ = src[2];
+               src += 3;
             }
-
-            buffer->set_range(buffer->range_offset(), 2 * numSamples);
+            buffer->release();
+            buffer = tmp;
+            ALOGV("length = %d", buffer->range_length());
         }
     }
 

--- a/media/libstagefright/WAVExtractor.cpp
+++ b/media/libstagefright/WAVExtractor.cpp
@@ -437,7 +437,7 @@ status_t WAVSource::read(
         maxBytesToRead = 3*(kMaxFrameSize/4);
     } else
         maxBytesToRead = kMaxFrameSize;
-    ALOGV("%s mBitsPerSample %d, kMaxFrameSize %d, ",
+    ALOGV("%s mBitsPerSample %d, kMaxFrameSize %zu, ",
           __func__, mBitsPerSample, kMaxFrameSize);
 
     size_t maxBytesAvailable =
@@ -504,7 +504,7 @@ status_t WAVSource::read(
             tmp->set_range(0, 4 * numBytes);
             int8_t *dst = (int8_t *)tmp->data();
             const uint8_t *src = (const uint8_t *)buffer->data();
-            ALOGV("numBytes = %d", numBytes);
+            ALOGV("numBytes = %zd", numBytes);
             while(numBytes-- > 0) {
                *dst++ = 0x0;
                *dst++ = src[0];
@@ -514,7 +514,7 @@ status_t WAVSource::read(
             }
             buffer->release();
             buffer = tmp;
-            ALOGV("length = %d", buffer->range_length());
+            ALOGV("length = %zu", buffer->range_length());
         }
     }
 

--- a/media/libstagefright/codecs/m4v_h263/enc/SoftMPEG4Encoder.cpp
+++ b/media/libstagefright/codecs/m4v_h263/enc/SoftMPEG4Encoder.cpp
@@ -37,6 +37,10 @@
 
 #include <inttypes.h>
 
+#ifndef INT32_MAX
+#define INT32_MAX   2147483647
+#endif
+
 namespace android {
 
 template<class T>
@@ -137,6 +141,11 @@ OMX_ERRORTYPE SoftMPEG4Encoder::initEncParams() {
     if (mColorFormat != OMX_COLOR_FormatYUV420Planar || mInputDataIsMeta) {
         // Color conversion is needed.
         free(mInputFrameData);
+        mInputFrameData = NULL;
+        if (((uint64_t)mWidth * mHeight) > ((uint64_t)INT32_MAX / 3)) {
+            ALOGE("b/25812794, Buffer size is too big.");
+            return OMX_ErrorBadParameter;
+        }
         mInputFrameData =
             (uint8_t *) malloc((mWidth * mHeight * 3 ) >> 1);
         CHECK(mInputFrameData != NULL);

--- a/media/libstagefright/codecs/on2/enc/SoftVPXEncoder.cpp
+++ b/media/libstagefright/codecs/on2/enc/SoftVPXEncoder.cpp
@@ -26,6 +26,10 @@
 #include <media/stagefright/foundation/ADebug.h>
 #include <media/stagefright/MediaDefs.h>
 
+#ifndef INT32_MAX
+#define INT32_MAX   2147483647
+#endif
+
 namespace android {
 
 template<class T>
@@ -315,6 +319,11 @@ status_t SoftVPXEncoder::initEncoder() {
 
     if (mColorFormat != OMX_COLOR_FormatYUV420Planar || mInputDataIsMeta) {
         free(mConversionBuffer);
+        mConversionBuffer = NULL;
+        if (((uint64_t)mWidth * mHeight) > ((uint64_t)INT32_MAX / 3)) {
+            ALOGE("b/25812794, Buffer size is too big.");
+            return UNKNOWN_ERROR;
+        }
         mConversionBuffer = (uint8_t *)malloc(mWidth * mHeight * 3 / 2);
         if (mConversionBuffer == NULL) {
             ALOGE("Allocating conversion buffer failed.");

--- a/media/libstagefright/codecs/raw/SoftRaw.cpp
+++ b/media/libstagefright/codecs/raw/SoftRaw.cpp
@@ -42,7 +42,8 @@ SoftRaw::SoftRaw(
     : SimpleSoftOMXComponent(name, callbacks, appData, component),
       mSignalledError(false),
       mChannelCount(2),
-      mSampleRate(44100) {
+      mSampleRate(44100),
+      mBitsPerSample(16) {
     initPorts();
     CHECK_EQ(initDecoder(), (status_t)OK);
 }
@@ -110,7 +111,7 @@ OMX_ERRORTYPE SoftRaw::internalGetParameter(
             pcmParams->eNumData = OMX_NumericalDataSigned;
             pcmParams->eEndian = OMX_EndianBig;
             pcmParams->bInterleaved = OMX_TRUE;
-            pcmParams->nBitPerSample = 16;
+            pcmParams->nBitPerSample = mBitsPerSample;
             pcmParams->ePCMMode = OMX_AUDIO_PCMModeLinear;
             pcmParams->eChannelMapping[0] = OMX_AUDIO_ChannelLF;
             pcmParams->eChannelMapping[1] = OMX_AUDIO_ChannelRF;
@@ -154,6 +155,7 @@ OMX_ERRORTYPE SoftRaw::internalSetParameter(
 
             mChannelCount = pcmParams->nChannels;
             mSampleRate = pcmParams->nSamplingRate;
+            mBitsPerSample = pcmParams->nBitPerSample;
 
             return OMX_ErrorNone;
         }

--- a/media/libstagefright/codecs/raw/SoftRaw.h
+++ b/media/libstagefright/codecs/raw/SoftRaw.h
@@ -50,6 +50,7 @@ private:
 
     int32_t mChannelCount;
     int32_t mSampleRate;
+    int32_t mBitsPerSample;
 
     void initPorts();
     status_t initDecoder();

--- a/media/libstagefright/colorconversion/SoftwareRenderer.cpp
+++ b/media/libstagefright/colorconversion/SoftwareRenderer.cpp
@@ -150,11 +150,20 @@ void SoftwareRenderer::resetFormatIfChanged(const sp<AMessage> &format) {
     CHECK(mCropHeight > 0);
     CHECK(mConverter == NULL || mConverter->isValid());
 
+#ifdef EXYNOS4_ENHANCEMENTS
+    CHECK_EQ(0,
+            native_window_set_usage(
+            mNativeWindow.get(),
+            GRALLOC_USAGE_SW_READ_NEVER | GRALLOC_USAGE_SW_WRITE_OFTEN
+            | GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_EXTERNAL_DISP
+            | GRALLOC_USAGE_HW_FIMC1));
+#else
     CHECK_EQ(0,
             native_window_set_usage(
             mNativeWindow.get(),
             GRALLOC_USAGE_SW_READ_NEVER | GRALLOC_USAGE_SW_WRITE_OFTEN
             | GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_EXTERNAL_DISP));
+#endif
 
     CHECK_EQ(0,
             native_window_set_scaling_mode(
@@ -282,13 +291,25 @@ std::list<FrameRenderTracker::Info> SoftwareRenderer::render(
         const uint8_t *src_uv = (const uint8_t *)data
                 + mWidth * (mHeight - mCropTop / 2);
 
-        uint8_t *dst_y = (uint8_t *)dst;
+#ifdef EXYNOS4_ENHANCEMENTS
+        void *pYUVBuf[3];
 
+        CHECK_EQ(0, mapper.unlock(buf->handle));
+        CHECK_EQ(0, mapper.lock(
+                buf->handle, GRALLOC_USAGE_SW_WRITE_OFTEN | GRALLOC_USAGE_YUV_ADDR, bounds, pYUVBuf));
+
+        size_t dst_c_stride = buf->stride / 2;
+        uint8_t *dst_y = (uint8_t *)pYUVBuf[0];
+        uint8_t *dst_v = (uint8_t *)pYUVBuf[1];
+        uint8_t *dst_u = (uint8_t *)pYUVBuf[2];
+#else
+        uint8_t *dst_y = (uint8_t *)dst;
         size_t dst_y_size = buf->stride * buf->height;
         size_t dst_c_stride = ALIGN(buf->stride / 2, 16);
         size_t dst_c_size = dst_c_stride * buf->height / 2;
         uint8_t *dst_v = dst_y + dst_y_size;
         uint8_t *dst_u = dst_v + dst_c_size;
+#endif
 
         for (int y = 0; y < mCropHeight; ++y) {
             memcpy(dst_y, src_y, mCropWidth);

--- a/media/libstagefright/httplive/Android.mk
+++ b/media/libstagefright/httplive/Android.mk
@@ -11,6 +11,8 @@ LOCAL_SRC_FILES:=               \
 
 LOCAL_C_INCLUDES:= \
 	$(TOP)/frameworks/av/media/libstagefright \
+	$(TOP)/frameworks/av/media/libavextensions \
+        $(TOP)/frameworks/av/media/libstagefright/mpeg2ts \
 	$(TOP)/frameworks/native/include/media/openmax
 
 LOCAL_CFLAGS += -Werror -Wall

--- a/media/libstagefright/httplive/PlaylistFetcher.cpp
+++ b/media/libstagefright/httplive/PlaylistFetcher.cpp
@@ -33,6 +33,7 @@
 #include <media/stagefright/MediaDefs.h>
 #include <media/stagefright/MetaData.h>
 #include <media/stagefright/Utils.h>
+#include <stagefright/AVExtensions.h>
 
 #include <ctype.h>
 #include <inttypes.h>
@@ -1712,7 +1713,8 @@ status_t PlaylistFetcher::extractAndQueueAccessUnitsFromTs(const sp<ABuffer> &bu
         const char *mime;
         sp<MetaData> format  = source->getFormat();
         bool isAvc = format != NULL && format->findCString(kKeyMIMEType, &mime)
-                && !strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_AVC);
+                && (!strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_AVC) ||
+                    !strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_HEVC));
 
         sp<ABuffer> accessUnit;
         status_t finalResult;
@@ -1734,7 +1736,7 @@ status_t PlaylistFetcher::extractAndQueueAccessUnitsFromTs(const sp<ABuffer> &bu
                             (long long)timeUs - mStartTimeUs,
                             mIDRFound);
                     if (isAvc) {
-                        if (IsIDR(accessUnit)) {
+                        if (IsIDR(accessUnit) || AVUtils::get()->IsHevcIDR(accessUnit)) {
                             mVideoBuffer->clear();
                             FSLOGV(stream, "found IDR, clear mVideoBuffer");
                             mIDRFound = true;

--- a/media/libstagefright/include/AACExtractor.h
+++ b/media/libstagefright/include/AACExtractor.h
@@ -21,6 +21,7 @@
 #include <media/stagefright/MediaExtractor.h>
 
 #include <utils/Vector.h>
+#include "include/APE.h"
 
 namespace android {
 
@@ -47,6 +48,9 @@ private:
 
     Vector<uint64_t> mOffsetVector;
     int64_t mFrameDurationUs;
+
+    APE ape;
+    sp<MetaData> mApeMeta;
 
     AACExtractor(const AACExtractor &);
     AACExtractor &operator=(const AACExtractor &);

--- a/media/libstagefright/include/APE.h
+++ b/media/libstagefright/include/APE.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Texas Instruments - http://www.ti.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef APE_TAG_H_
+
+#define APE_TAG_H_
+
+#include <utils/RefBase.h>
+#include <media/stagefright/DataSource.h>
+#include <media/stagefright/MetaData.h>
+
+namespace android {
+
+class APE{
+public:
+    APE();
+    ~APE();
+    bool isAPE(uint8_t *apeTag) const;
+    bool parseAPE(const sp<DataSource> &source, off64_t offset,
+            sp<MetaData> &meta);
+
+private:
+    uint32_t itemNumber;
+    uint32_t itemFlags;
+    size_t lenValue;
+};
+
+} //namespace android
+
+#endif //APE_TAG_H_

--- a/media/libstagefright/include/AwesomePlayer.h
+++ b/media/libstagefright/include/AwesomePlayer.h
@@ -193,6 +193,7 @@ private:
     uint32_t mFlags;
     uint32_t mExtractorFlags;
     uint32_t mSinceLastDropped;
+    bool mDropFramesDisable; // hevc test
 
     int64_t mTimeSourceDeltaUs;
     int64_t mVideoTimeUs;

--- a/media/libstagefright/matroska/MatroskaExtractor.cpp
+++ b/media/libstagefright/matroska/MatroskaExtractor.cpp
@@ -521,8 +521,9 @@ status_t MatroskaSource::readBlock() {
     const mkvparser::Block *block = mBlockIter.block();
 
     int64_t timeUs = mBlockIter.blockTimeUs();
+    int frameCount = block->GetFrameCount();
 
-    for (int i = 0; i < block->GetFrameCount(); ++i) {
+    for (int i = 0; i < frameCount; ++i) {
         const mkvparser::Block::Frame &frame = block->GetFrame(i);
 
         MediaBuffer *mbuf = new MediaBuffer(frame.len);
@@ -541,6 +542,27 @@ status_t MatroskaSource::readBlock() {
     }
 
     mBlockIter.advance();
+
+    if (!mBlockIter.eos() && frameCount > 1) {
+        // For files with lacing enabled, we need to amend they kKeyTime of
+        // each frame so that their kKeyTime are advanced accordingly (instead
+        // of being set to the same value). To do this, we need to find out
+        // the duration of the block using the start time of the next block.
+        int64_t duration = mBlockIter.blockTimeUs() - timeUs;
+        int64_t durationPerFrame = duration / frameCount;
+        int64_t durationRemainder = duration % frameCount;
+
+        // We split duration to each of the frame, distributing the remainder (if any)
+        // to the later frames. The later frames are processed first due to the
+        // use of the iterator for the doubly linked list
+        List<MediaBuffer *>::iterator it = mPendingFrames.end();
+        for (int i = frameCount - 1; i >= 0; --i) {
+            --it;
+            int64_t frameRemainder = durationRemainder >= frameCount - i ? 1 : 0;
+            int64_t frameTimeUs = timeUs + durationPerFrame * i + frameRemainder;
+            (*it)->meta_data()->setInt64(kKeyTime, frameTimeUs);
+        }
+    }
 
     return OK;
 }

--- a/media/libstagefright/matroska/MatroskaExtractor.cpp
+++ b/media/libstagefright/matroska/MatroskaExtractor.cpp
@@ -240,13 +240,12 @@ MatroskaSource::MatroskaSource(
         mType = HEVC;
 
         uint32_t type;
-        const void *data;
+        const uint8_t *data;
         size_t size;
-        CHECK(meta->findData(kKeyHVCC, &type, &data, &size));
+        CHECK(meta->findData(kKeyHVCC, &type, (const void **)&data, &size));
 
-        const uint8_t *ptr = (const uint8_t *)data;
         CHECK(size >= 7);
-        mNALSizeLen = 1 + (ptr[14 + 7] & 3);
+        mNALSizeLen = 1 + (data[14 + 7] & 3);
         ALOGV("mNALSizeLen = %zu", mNALSizeLen);
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_AAC)) {
         mType = AAC;
@@ -1028,7 +1027,7 @@ void MatroskaExtractor::addTracks() {
                     }
                 } else if (!strcmp("V_MPEGH/ISO/HEVC", codecID)) {
                     meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_VIDEO_HEVC);
-                    meta->setData(kKeyHVCC, 0, codecPrivate, codecPrivateSize);
+                    meta->setData(kKeyHVCC, kTypeHVCC, codecPrivate, codecPrivateSize);
 
                 } else if (!strcmp("V_VP8", codecID)) {
                     meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_VIDEO_VP8);
@@ -1051,7 +1050,9 @@ void MatroskaExtractor::addTracks() {
 
                 if (!strcmp("A_AAC", codecID)) {
                     meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_AUDIO_AAC);
-                    CHECK(codecPrivateSize >= 2);
+                    if (codecPrivateSize < 2) {
+                        return;
+                    }
 
                     addESDSFromCodecPrivate(
                             meta, true, codecPrivate, codecPrivateSize);

--- a/media/libstagefright/matroska/MatroskaExtractor.cpp
+++ b/media/libstagefright/matroska/MatroskaExtractor.cpp
@@ -31,6 +31,7 @@
 #include <media/stagefright/MetaData.h>
 #include <media/stagefright/Utils.h>
 #include <utils/String8.h>
+#include <media/stagefright/foundation/ABitReader.h>
 
 #include <inttypes.h>
 
@@ -840,6 +841,17 @@ static void storeSize(uint8_t *data, size_t &idx, size_t size) {
 static void addESDSFromCodecPrivate(
         const sp<MetaData> &meta,
         bool isAudio, const void *priv, size_t privSize) {
+
+    if(isAudio) {
+        ABitReader br((const uint8_t *)priv, privSize);
+        uint32_t objectType = br.getBits(5);
+
+        if (objectType == 31) {  // AAC-ELD => additional 6 bits
+            objectType = 32 + br.getBits(6);
+        }
+
+        meta->setInt32(kKeyAACAOT, objectType);
+    }
 
     int privSizeBytesRequired = bytesForSize(privSize);
     int esdsSize2 = 14 + privSizeBytesRequired + privSize;

--- a/media/libstagefright/matroska/MatroskaExtractor.cpp
+++ b/media/libstagefright/matroska/MatroskaExtractor.cpp
@@ -137,6 +137,7 @@ private:
     enum Type {
         AVC,
         AAC,
+        HEVC,
         OTHER
     };
 
@@ -234,6 +235,18 @@ MatroskaSource::MatroskaSource(
         CHECK_GE(avccSize, 5u);
 
         mNALSizeLen = 1 + (avcc[4] & 3);
+        ALOGV("mNALSizeLen = %zu", mNALSizeLen);
+    } else if (!strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_HEVC)) {
+        mType = HEVC;
+
+        uint32_t type;
+        const void *data;
+        size_t size;
+        CHECK(meta->findData(kKeyHVCC, &type, &data, &size));
+
+        const uint8_t *ptr = (const uint8_t *)data;
+        CHECK(size >= 7);
+        mNALSizeLen = 1 + (ptr[14 + 7] & 3);
         ALOGV("mNALSizeLen = %zu", mNALSizeLen);
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_AUDIO_AAC)) {
         mType = AAC;
@@ -604,7 +617,7 @@ status_t MatroskaSource::read(
     MediaBuffer *frame = *mPendingFrames.begin();
     mPendingFrames.erase(mPendingFrames.begin());
 
-    if (mType != AVC) {
+    if (mType != AVC && mType != HEVC) {
         if (targetSampleTimeUs >= 0ll) {
             frame->meta_data()->setInt64(
                     kKeyTargetTime, targetSampleTimeUs);
@@ -1013,6 +1026,10 @@ void MatroskaExtractor::addTracks() {
                                 codecID);
                         continue;
                     }
+                } else if (!strcmp("V_MPEGH/ISO/HEVC", codecID)) {
+                    meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_VIDEO_HEVC);
+                    meta->setData(kKeyHVCC, 0, codecPrivate, codecPrivateSize);
+
                 } else if (!strcmp("V_VP8", codecID)) {
                     meta->setCString(kKeyMIMEType, MEDIA_MIMETYPE_VIDEO_VP8);
                 } else if (!strcmp("V_VP9", codecID)) {

--- a/media/libstagefright/mpeg2ts/ATSParser.cpp
+++ b/media/libstagefright/mpeg2ts/ATSParser.cpp
@@ -57,6 +57,7 @@
 #include <utils/Vector.h>
 
 #include <inttypes.h>
+#include <stagefright/AVExtensions.h>
 
 namespace android {
 
@@ -622,6 +623,12 @@ ATSParser::Stream::Stream(
                     (mProgram->parserFlags() & ALIGNED_VIDEO_DATA)
                         ? ElementaryStreamQueue::kFlag_AlignedData : 0);
             break;
+        case STREAMTYPE_H265:
+            mQueue = AVFactory::get()->createESQueue(
+                    ElementaryStreamQueue::H265,
+                    (mProgram->parserFlags() & ALIGNED_VIDEO_DATA)
+                        ? ElementaryStreamQueue::kFlag_AlignedData : 0);
+            break;
         case STREAMTYPE_MPEG2_AUDIO_ADTS:
             mQueue = new ElementaryStreamQueue(ElementaryStreamQueue::AAC);
             break;
@@ -760,6 +767,7 @@ status_t ATSParser::Stream::parse(
 bool ATSParser::Stream::isVideo() const {
     switch (mStreamType) {
         case STREAMTYPE_H264:
+        case STREAMTYPE_H265:
         case STREAMTYPE_MPEG1_VIDEO:
         case STREAMTYPE_MPEG2_VIDEO:
         case STREAMTYPE_MPEG4_VIDEO:
@@ -1111,9 +1119,11 @@ void ATSParser::Stream::onPayloadData(
                      mElementaryPID, mStreamType);
 
                 const char *mime;
-                if (meta->findCString(kKeyMIMEType, &mime)
-                        && !strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_AVC)
-                        && !IsIDR(accessUnit)) {
+                if (meta->findCString(kKeyMIMEType, &mime) &&
+                        ((!strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_AVC)
+                           && !IsIDR(accessUnit)) ||
+                         (!strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_HEVC)
+                          && !AVUtils::get()->IsHevcIDR(accessUnit)))) {
                     continue;
                 }
                 mSource = new AnotherPacketSource(meta);

--- a/media/libstagefright/mpeg2ts/ATSParser.h
+++ b/media/libstagefright/mpeg2ts/ATSParser.h
@@ -146,6 +146,7 @@ struct ATSParser : public RefBase {
         STREAMTYPE_MPEG4_VIDEO          = 0x10,
         STREAMTYPE_METADATA             = 0x15,
         STREAMTYPE_H264                 = 0x1b,
+        STREAMTYPE_H265                 = 0x24,
 
         // From ATSC A/53 Part 3:2009, 6.7.1
         STREAMTYPE_AC3                  = 0x81,

--- a/media/libstagefright/mpeg2ts/Android.mk
+++ b/media/libstagefright/mpeg2ts/Android.mk
@@ -11,7 +11,8 @@ LOCAL_SRC_FILES:=                 \
 
 LOCAL_C_INCLUDES:= \
 	$(TOP)/frameworks/av/media/libstagefright \
-	$(TOP)/frameworks/native/include/media/openmax
+	$(TOP)/frameworks/native/include/media/openmax \
+        $(TOP)/frameworks/av/media/libavextensions \
 
 LOCAL_CFLAGS += -Werror -Wall
 LOCAL_CLANG := true

--- a/media/libstagefright/mpeg2ts/ESQueue.cpp
+++ b/media/libstagefright/mpeg2ts/ESQueue.cpp
@@ -55,6 +55,7 @@
 #ifdef DOLBY_ENABLE
 #include "DolbyESQueueExtImpl.h"
 #endif // DOLBY_END
+#include <stagefright/AVExtensions.h>
 
 namespace android {
 
@@ -280,6 +281,7 @@ status_t ElementaryStreamQueue::appendData(
     if (mBuffer == NULL || mBuffer->size() == 0) {
         switch (mMode) {
             case H264:
+            case H265:
             case MPEG_VIDEO:
             {
 #if 0
@@ -546,6 +548,8 @@ sp<ABuffer> ElementaryStreamQueue::dequeueAccessUnit() {
     switch (mMode) {
         case H264:
             return dequeueAccessUnitH264();
+        case H265:
+            return dequeueAccessUnitH265();
         case AAC:
             return dequeueAccessUnitAAC();
         case AC3:

--- a/media/libstagefright/mpeg2ts/ESQueue.h
+++ b/media/libstagefright/mpeg2ts/ESQueue.h
@@ -38,6 +38,8 @@
 #define ES_QUEUE_H_
 
 #include <media/stagefright/foundation/ABase.h>
+#include <media/stagefright/foundation/ABuffer.h>
+#include <media/stagefright/MetaData.h>
 #include <utils/Errors.h>
 #include <utils/List.h>
 #include <utils/RefBase.h>
@@ -46,10 +48,12 @@ namespace android {
 
 struct ABuffer;
 class MetaData;
+struct AVUtils;
 
 struct ElementaryStreamQueue {
     enum Mode {
         H264,
+        H265,
         AAC,
         AC3,
 #ifdef DOLBY_ENABLE
@@ -67,6 +71,7 @@ struct ElementaryStreamQueue {
         kFlag_AlignedData = 1,
     };
     ElementaryStreamQueue(Mode mode, uint32_t flags = 0);
+    virtual ~ElementaryStreamQueue() {};
 
     status_t appendData(const void *data, size_t size, int64_t timeUs);
     void signalEOS();
@@ -76,7 +81,7 @@ struct ElementaryStreamQueue {
 
     sp<MetaData> getFormat();
 
-private:
+protected:
     struct RangeInfo {
         int64_t mTimestampUs;
         size_t mLength;
@@ -104,11 +109,15 @@ private:
     unsigned independent_streams_processed;
     unsigned independent_stream_num_channels;
 #endif // DOLBY_END
+    virtual sp<ABuffer> dequeueAccessUnitH265() {
+        return NULL;
+    };
 
     // consume a logical (compressed) access unit of size "size",
     // returns its timestamp in us (or -1 if no time information).
     int64_t fetchTimestamp(size_t size);
 
+private:
     DISALLOW_EVIL_CONSTRUCTORS(ElementaryStreamQueue);
 };
 

--- a/media/libstagefright/omx/OMXMaster.cpp
+++ b/media/libstagefright/omx/OMXMaster.cpp
@@ -25,52 +25,58 @@
 #include <dlfcn.h>
 
 #include <media/stagefright/foundation/ADebug.h>
+#include <cutils/properties.h>
 
 namespace android {
 
-OMXMaster::OMXMaster()
-    : mVendorLibHandle(NULL) {
+OMXMaster::OMXMaster() {
     addVendorPlugin();
     addPlugin(new SoftOMXPlugin);
+    addUserPlugin();
 }
 
 OMXMaster::~OMXMaster() {
     clearPlugins();
-
-    if (mVendorLibHandle != NULL) {
-        dlclose(mVendorLibHandle);
-        mVendorLibHandle = NULL;
-    }
 }
 
 void OMXMaster::addVendorPlugin() {
     addPlugin("libstagefrighthw.so");
 }
 
-void OMXMaster::addPlugin(const char *libname) {
-    mVendorLibHandle = dlopen(libname, RTLD_NOW);
+void OMXMaster::addUserPlugin() {
+    char plugin[PROPERTY_VALUE_MAX];
+    if (property_get("media.sf.omx-plugin", plugin, NULL)) {
+        addPlugin(plugin);
+    }
+}
 
-    if (mVendorLibHandle == NULL) {
+void OMXMaster::addPlugin(const char *libname) {
+    void* handle = dlopen(libname, RTLD_NOW);
+
+    if (handle == NULL) {
         return;
     }
 
     typedef OMXPluginBase *(*CreateOMXPluginFunc)();
     CreateOMXPluginFunc createOMXPlugin =
         (CreateOMXPluginFunc)dlsym(
-                mVendorLibHandle, "createOMXPlugin");
+                handle, "createOMXPlugin");
     if (!createOMXPlugin)
         createOMXPlugin = (CreateOMXPluginFunc)dlsym(
-                mVendorLibHandle, "_ZN7android15createOMXPluginEv");
+                handle, "_ZN7android15createOMXPluginEv");
 
     if (createOMXPlugin) {
-        addPlugin((*createOMXPlugin)());
+        addPlugin((*createOMXPlugin)(), handle);
     }
 }
 
-void OMXMaster::addPlugin(OMXPluginBase *plugin) {
+void OMXMaster::addPlugin(OMXPluginBase *plugin, void *handle) {
+    if (plugin == 0) {
+       return;
+    }
     Mutex::Autolock autoLock(mLock);
 
-    mPlugins.push_back(plugin);
+    mPlugins.add(plugin, handle);
 
     OMX_U32 index = 0;
 
@@ -100,21 +106,32 @@ void OMXMaster::clearPlugins() {
     Mutex::Autolock autoLock(mLock);
 
     typedef void (*DestroyOMXPluginFunc)(OMXPluginBase*);
-    DestroyOMXPluginFunc destroyOMXPlugin =
-        (DestroyOMXPluginFunc)dlsym(
-                mVendorLibHandle, "destroyOMXPlugin");
 
-    mPluginByComponentName.clear();
+    for (unsigned int i = 0; i < mPlugins.size(); i++) {
+        OMXPluginBase *plugin = mPlugins.keyAt(i);
+        if (plugin != NULL) {
+            void *handle = mPlugins.valueAt(i);
 
-    for (List<OMXPluginBase *>::iterator it = mPlugins.begin();
-            it != mPlugins.end(); ++it) {
-        if (destroyOMXPlugin)
-            destroyOMXPlugin(*it);
-        else
-            delete *it;
-        *it = NULL;
+            if (handle != NULL) {
+                DestroyOMXPluginFunc destroyOMXPlugin =
+                    (DestroyOMXPluginFunc)dlsym(
+                            handle, "destroyOMXPlugin");
+
+                if (destroyOMXPlugin)
+                    destroyOMXPlugin(plugin);
+                else
+                    delete plugin;
+
+                dlclose(handle);
+            } else {
+                delete plugin;
+            }
+
+            plugin = NULL;
+        }
     }
 
+    mPluginByComponentName.clear();
     mPlugins.clear();
 }
 

--- a/media/libstagefright/omx/OMXMaster.h
+++ b/media/libstagefright/omx/OMXMaster.h
@@ -51,15 +51,14 @@ struct OMXMaster : public OMXPluginBase {
 
 private:
     Mutex mLock;
-    List<OMXPluginBase *> mPlugins;
+    KeyedVector<OMXPluginBase *, void *> mPlugins;
     KeyedVector<String8, OMXPluginBase *> mPluginByComponentName;
     KeyedVector<OMX_COMPONENTTYPE *, OMXPluginBase *> mPluginByInstance;
 
-    void *mVendorLibHandle;
-
     void addVendorPlugin();
+    void addUserPlugin();
     void addPlugin(const char *libname);
-    void addPlugin(OMXPluginBase *plugin);
+    void addPlugin(OMXPluginBase *plugin, void *handle = NULL);
     void clearPlugins();
 
     OMXMaster(const OMXMaster &);

--- a/media/libstagefright/omx/SoftOMXPlugin.cpp
+++ b/media/libstagefright/omx/SoftOMXPlugin.cpp
@@ -101,6 +101,7 @@ OMX_ERRORTYPE SoftOMXPlugin::makeComponentInstance(
         OMX_COMPONENTTYPE **component) {
     ALOGV("makeComponentInstance '%s'", name);
 
+    dlerror(); // clear any existing error
     for (size_t i = 0; i < kNumComponents; ++i) {
         if (strcmp(name, kComponents[i].mName)) {
             continue;
@@ -118,6 +119,8 @@ OMX_ERRORTYPE SoftOMXPlugin::makeComponentInstance(
             return OMX_ErrorComponentNotFound;
         }
 
+        ALOGV("load component %s for %s", libName.c_str(), name);
+
         typedef SoftOMXComponent *(*CreateSoftOMXComponentFunc)(
                 const char *, const OMX_CALLBACKTYPE *,
                 OMX_PTR, OMX_COMPONENTTYPE **);
@@ -128,7 +131,8 @@ OMX_ERRORTYPE SoftOMXPlugin::makeComponentInstance(
                     "_Z22createSoftOMXComponentPKcPK16OMX_CALLBACKTYPE"
                     "PvPP17OMX_COMPONENTTYPE");
 
-        if (createSoftOMXComponent == NULL) {
+        if (const char *error = dlerror()) {
+            ALOGE("unable to dlsym %s: %s", libName.c_str(), error);
             dlclose(libHandle);
             libHandle = NULL;
 

--- a/services/audioflinger/AudioMixer.h
+++ b/services/audioflinger/AudioMixer.h
@@ -137,6 +137,7 @@ public:
         case AUDIO_FORMAT_PCM_8_BIT:
         case AUDIO_FORMAT_PCM_16_BIT:
         case AUDIO_FORMAT_PCM_24_BIT_PACKED:
+        case AUDIO_FORMAT_PCM_8_24_BIT:
         case AUDIO_FORMAT_PCM_32_BIT:
         case AUDIO_FORMAT_PCM_FLOAT:
             return true;

--- a/services/audioflinger/Threads.cpp
+++ b/services/audioflinger/Threads.cpp
@@ -2941,7 +2941,8 @@ bool AudioFlinger::PlaybackThread::threadLoop()
             }
 
             // only process effects if we're going to write
-            if (mSleepTimeUs == 0 && mType != OFFLOAD) {
+            if (mSleepTimeUs == 0 && mType != OFFLOAD &&
+                !(mType == DIRECT && mIsDirectPcm)) {
                 for (size_t i = 0; i < effectChains.size(); i ++) {
                     effectChains[i]->process_l();
                 }
@@ -2951,7 +2952,7 @@ bool AudioFlinger::PlaybackThread::threadLoop()
         // was read from audio track: process only updates effect state
         // and thus does have to be synchronized with audio writes but may have
         // to be called while waiting for async write callback
-        if (mType == OFFLOAD) {
+        if ((mType == OFFLOAD) || (mType == DIRECT && mIsDirectPcm)) {
             for (size_t i = 0; i < effectChains.size(); i ++) {
                 effectChains[i]->process_l();
             }

--- a/services/audioflinger/Threads.cpp
+++ b/services/audioflinger/Threads.cpp
@@ -2210,6 +2210,7 @@ void AudioFlinger::PlaybackThread::readOutputParameters_l()
             kUseFastMixer == FastMixer_Dynamic)) {
         size_t minNormalFrameCount = (kMinNormalSinkBufferSizeMs * mSampleRate) / 1000;
         size_t maxNormalFrameCount = (kMaxNormalSinkBufferSizeMs * mSampleRate) / 1000;
+
         // round up minimum and round down maximum to nearest 16 frames to satisfy AudioMixer
         minNormalFrameCount = (minNormalFrameCount + 15) & ~15;
         maxNormalFrameCount = maxNormalFrameCount & ~15;
@@ -2225,19 +2226,6 @@ void AudioFlinger::PlaybackThread::readOutputParameters_l()
             } else {
                 multiplier = (double) maxNormalFrameCount / (double) mFrameCount;
             }
-        } else {
-            // prefer an even multiplier, for compatibility with doubling of fast tracks due to HAL
-            // SRC (it would be unusual for the normal sink buffer size to not be a multiple of fast
-            // track, but we sometimes have to do this to satisfy the maximum frame count
-            // constraint)
-            // FIXME this rounding up should not be done if no HAL SRC
-            uint32_t truncMult = (uint32_t) multiplier;
-            if ((truncMult & 1)) {
-                if ((truncMult + 1) * mFrameCount <= maxNormalFrameCount) {
-                    ++truncMult;
-                }
-            }
-            multiplier = (double) truncMult;
         }
     }
     mNormalFrameCount = multiplier * mFrameCount;

--- a/services/audiopolicy/service/AudioPolicyInterfaceImpl.cpp
+++ b/services/audiopolicy/service/AudioPolicyInterfaceImpl.cpp
@@ -187,6 +187,20 @@ status_t AudioPolicyService::startOutput(audio_io_handle_t output,
         return NO_INIT;
     }
     ALOGV("startOutput()");
+    return mOutputCommandThread->startOutputCommand(output, stream, session);
+}
+
+status_t AudioPolicyService::doStartOutput(audio_io_handle_t output,
+                                           audio_stream_type_t stream,
+                                           audio_session_t session)
+{
+    if (uint32_t(stream) >= AUDIO_STREAM_CNT) {
+        return BAD_VALUE;
+    }
+    if (mAudioPolicyManager == NULL) {
+        return NO_INIT;
+    }
+    ALOGV("doStartOutput()");
     sp<AudioPolicyEffects>audioPolicyEffects;
     {
         Mutex::Autolock _l(mLock);

--- a/services/audiopolicy/service/AudioPolicyService.cpp
+++ b/services/audiopolicy/service/AudioPolicyService.cpp
@@ -478,6 +478,19 @@ bool AudioPolicyService::AudioCommandThread::threadLoop()
                             data->mVolume);
                     command->mStatus = AudioSystem::setVoiceVolume(data->mVolume);
                     }break;
+                case START_OUTPUT: {
+                    StartOutputData *data = (StartOutputData *)command->mParam.get();
+                    ALOGV("AudioCommandThread() processing start output %d",
+                            data->mIO);
+                    svc = mService.promote();
+                    if (svc == 0) {
+                        command->mStatus = UNKNOWN_ERROR;
+                        break;
+                    }
+                    mLock.unlock();
+                    command->mStatus = svc->doStartOutput(data->mIO, data->mStream, data->mSession);
+                    mLock.lock();
+                    }break;
                 case STOP_OUTPUT: {
                     StopOutputData *data = (StopOutputData *)command->mParam.get();
                     ALOGV("AudioCommandThread() processing stop output %d",
@@ -712,6 +725,22 @@ status_t AudioPolicyService::AudioCommandThread::voiceVolumeCommand(float volume
     command->mWaitStatus = true;
     ALOGV("AudioCommandThread() adding set voice volume volume %f", volume);
     return sendCommand(command, delayMs);
+}
+
+status_t AudioPolicyService::AudioCommandThread::startOutputCommand(audio_io_handle_t output,
+                                                                    audio_stream_type_t stream,
+                                                                    audio_session_t session)
+{
+    sp<AudioCommand> command = new AudioCommand();
+    command->mCommand = START_OUTPUT;
+    sp<StartOutputData> data = new StartOutputData();
+    data->mIO = output;
+    data->mStream = stream;
+    data->mSession = session;
+    command->mParam = data;
+    command->mWaitStatus = true;
+    ALOGV("AudioCommandThread() adding start output %d", output);
+    return sendCommand(command);
 }
 
 void AudioPolicyService::AudioCommandThread::stopOutputCommand(audio_io_handle_t output,

--- a/services/audiopolicy/service/AudioPolicyService.h
+++ b/services/audiopolicy/service/AudioPolicyService.h
@@ -202,6 +202,9 @@ public:
                                       audio_io_handle_t *handle);
     virtual status_t stopAudioSource(audio_io_handle_t handle);
 
+            status_t doStartOutput(audio_io_handle_t output,
+                                   audio_stream_type_t stream,
+                                   audio_session_t session);
             status_t doStopOutput(audio_io_handle_t output,
                                   audio_stream_type_t stream,
                                   audio_session_t session);
@@ -249,6 +252,7 @@ private:
             SET_VOLUME,
             SET_PARAMETERS,
             SET_VOICE_VOLUME,
+            START_OUTPUT,
             STOP_OUTPUT,
             RELEASE_OUTPUT,
             CREATE_AUDIO_PATCH,
@@ -277,6 +281,9 @@ private:
                     status_t    parametersCommand(audio_io_handle_t ioHandle,
                                             const char *keyValuePairs, int delayMs = 0);
                     status_t    voiceVolumeCommand(float volume, int delayMs = 0);
+                    status_t    startOutputCommand(audio_io_handle_t output,
+                                                   audio_stream_type_t stream,
+                                                   audio_session_t session);
                     void        stopOutputCommand(audio_io_handle_t output,
                                                   audio_stream_type_t stream,
                                                   audio_session_t session);
@@ -347,6 +354,13 @@ private:
         class VoiceVolumeData : public AudioCommandData {
         public:
             float mVolume;
+        };
+
+        class StartOutputData : public AudioCommandData {
+        public:
+            audio_io_handle_t mIO;
+            audio_stream_type_t mStream;
+            audio_session_t mSession;
         };
 
         class StopOutputData : public AudioCommandData {


### PR DESCRIPTION
commit e41cc838b6212f8711c550522e8cefc95f003a67
Author: rINanDO drjisakh@gmail.com
Date:   Mon Aug 10 13:56:56 2015 +0200

```
stagefright: Exynos4 MPEG4 decoder should set native color format.

Change-Id: I41bee77d48fc0b35691b94585de10269579ae789
```

commit a50263c53a1ecd0f75688f7042dd5e5d9badbc39
Author: Caio Schnepper caioschnepper@gmail.com
Date:   Wed Jun 10 22:26:07 2015 -0300

```
libstagefright: back off exynos4_enhancements HWC_HWOVERLAY usage

The open source hwc doesn't support the
GRALLOC_USAGE_HW_FIMC1 | GRALLOC_USAGE_HWC_HWOVERLAY
combination. Removing HWC_HWOVERLAY allows FIMC1 to do
decode/color conversion.

Change-Id: Ibdfa9e5dd170e99e0d994540979e88e519931641
```

commit 63286a333bde1aa047de4e2fde8da1b59e42a16d
Author: Ricardo Cerqueira cyanogenmod@cerqueira.org
Date:   Sun Nov 3 02:45:19 2013 +0000

```
exynos4: libstragefright: add support for samsung colorformat/omx/mfc

Source:
http://git.insignal.co.kr/samsung/exynos/android/platform/frameworks/av/commit/?h=exynos-jb&id=1614612f7ca2a00473d202dbedcb135fadc608ad

Conflicts:

    media/libstagefright/ACodec.cpp
    media/libstagefright/OMXCodec.cpp

cherry pick from 906eba9f

Change-Id: I1c174f8e9fa9bd3ed16a0399f070b6680f6a331c
```

Based on: http://review.cyanogenmod.org/#/c/123073/

Change-Id: I47f5b09b37ea5376a45c80c9dd91a7fbd0c3361a
